### PR TITLE
non-default fields first

### DIFF
--- a/common/__init__.py
+++ b/common/__init__.py
@@ -28,10 +28,11 @@ logger.addHandler(handler)
 
 @dataclass
 class Config:
+    # NOTE: non-default fields must come first
     stage: str
     account_id: str
     region_name: str
+    google_package_name: str
     headless: str = "http://localhost"
     kms_key_id: Optional[str] = None
-    google_package_name: str
     google_credential: Optional[str] = None


### PR DESCRIPTION
When using pydantic dataclass, non-default fields must come first.