### PR TITLE
Add purchase_count into product list API

### DIFF
--- a/iap/api/product.py
+++ b/iap/api/product.py
@@ -44,9 +44,12 @@ def product_list(agent_addr: str, sess=Depends(session)):
                 break
 
         # Check purchase history
+        schema = schema_dict[product.id]
         if product.daily_limit:
-            product.buyable = get_purchase_count(sess, agent_addr, product.id, hour_limit=24) < product.daily_limit
+            schema.purchase_count = get_purchase_count(sess, agent_addr, product.id, hour_limit=24)
+            schema.buyable = schema.purchase_count < product.daily_limit
         elif product.weekly_limit:
-            product.buyable = get_purchase_count(sess, agent_addr, product.id, hour_limit=24 * 7) < product.weekly_limit
+            schema.purchase_count = get_purchase_count(sess, agent_addr, product.id, hour_limit=24 * 7)
+            schema.buyable = schema.purchase_count < product.weekly_limit
 
     return list(schema_dict.values())

--- a/iap/schemas/product.py
+++ b/iap/schemas/product.py
@@ -36,6 +36,7 @@ class ProductSchema(BaseSchema):
     product_type: ProductType
     daily_limit: Optional[int] = None
     weekly_limit: Optional[int] = None
+    purchase_count: int = 0
     display_order: int
     active: bool
     buyable: bool = True

--- a/iap/utils.py
+++ b/iap/utils.py
@@ -3,11 +3,12 @@ import os
 from typing import List, Optional, Dict
 
 from gql.dsl import dsl_gql, DSLQuery
-from sqlalchemy import func, distinct, select
+from sqlalchemy import func, distinct, select, Date, cast
 
 from common import logger
 from common._crypto import Account
 from common._graphql import GQL
+from common.enums import ReceiptStatus
 from common.models.product import FungibleItemProduct
 from common.models.receipt import Receipt
 from common.utils import fetch_kms_key_id
@@ -23,10 +24,16 @@ def get_purchase_count(sess, agent_addr: str, product_id: int, hour_limit: int) 
     :param hour_limit: purchase history limit in hours. 24 for daily limit, 168(24*7) for weekly limit
     :return:
     """
-    start = datetime.datetime.utcnow() - datetime.timedelta(hours=hour_limit)
-    purchase_count = (sess.query(func.count(Receipt.id)).filter_by(product_id=product_id, agent_addr=agent_addr)
-                      .filter(Receipt.created_at >= start)
-                      ).scalar()
+    # NOTE: Subtract 24 hours from incoming hour_limit.
+    #  Because last 24 hours means today. Using `datetime.date()` function, timedelta -24 hours makes yesterday.
+    start = (datetime.datetime.utcnow() - datetime.timedelta(hours=hour_limit-24)).date()
+    purchase_count = (
+        sess.query(func.count(Receipt.id)).filter_by(product_id=product_id, agent_addr=agent_addr)
+        .filter(Receipt.status.in_(
+            (ReceiptStatus.INIT, ReceiptStatus.VALIDATION_REQUEST, ReceiptStatus.VALID)
+        ))
+        .filter(cast(Receipt.purchased_at, Date) >= start)
+    ).scalar()
     logger.debug(
         f"Agent {agent_addr} purchased product {product_id} {purchase_count} times in {hour_limit} hours from {start}"
     )


### PR DESCRIPTION
To show how many items player can buy, add `purchase_count` if there is a purchase_limit in product.