### PR TITLE
Remove stage prefix

### DIFF
--- a/iap/frontend/src/components/Navigation.svelte
+++ b/iap/frontend/src/components/Navigation.svelte
@@ -1,20 +1,19 @@
 <script>
   import {Navbar, NavBrand, NavHamburger, NavLi, NavUl} from "flowbite-svelte";
   import {STAGE} from "../const.js";
-  import {stageUrl} from "../util.js";
 
   export let current;
 </script>
 
 <Navbar let:hidden let:toggle color="form">
-  <NavBrand href={stageUrl("/")}>
+  <NavBrand href="/">
     <img src="/favicon.png" alt="9c" class="mr-3 h-6 sm:h-9"/>
     <span class="self-center whitespace-nowrap text-xl dark:text-white">9c IAP: {STAGE}</span>
   </NavBrand>
   <NavHamburger on:click={toggle}/>
   <NavUl {hidden}>
-    <NavLi href={stageUrl("/")} active={current === "home"}>Home</NavLi>
-    <NavLi href={stageUrl("/receipt")} active={current === "receipt"}>Receipt List</NavLi>
+    <NavLi href="/" active={current === "home"}>Home</NavLi>
+    <NavLi href="/receipt" active={current === "receipt"}>Receipt List</NavLi>
   </NavUl>
 </Navbar>
 

--- a/iap/frontend/src/routes/receipt/+page.svelte
+++ b/iap/frontend/src/routes/receipt/+page.svelte
@@ -12,12 +12,11 @@
   import {RECEIPT_STATUS_MAP, STAGE, STORE_MAP, TxStatus} from "../../const.js";
   import {DateTime} from "luxon";
   import Navigation from "../../components/Navigation.svelte";
-  import {stageUrl} from "../../util.js";
 
   let receiptList = [];
 
   const fetchReceiptList = async () => {
-    const resp = await fetch(stageUrl("/api/admin/receipt"));
+    const resp = await fetch("/api/admin/receipt");
     receiptList = await resp.json();
     return receiptList;
   }

--- a/iap/frontend/src/util.js
+++ b/iap/frontend/src/util.js
@@ -1,5 +1,0 @@
-import {STAGE} from "./const.js";
-
-export const stageUrl = (url) => {
-  return `${STAGE === "local" ? "" : `/${STAGE}`}${url}`;
-};

--- a/iap/main.py
+++ b/iap/main.py
@@ -22,7 +22,6 @@ app = FastAPI(
     title="Nine Chronicles In-app Purchase Validation Service",
     description="",
     version=__VERSION__,
-    root_path=f"/{stage}" if stage != "local" else "",
     debug=settings.DEBUG,
 )
 


### PR DESCRIPTION
Previously, `/STAGE` prefix is added to all URLs to easily recognize stage by url.
But this causes multiple URL 404 issues and delete prefix to resolve issue.