### PR TITLE
Make stage based routing works

### DIFF
--- a/iap/frontend/src/components/Navigation.svelte
+++ b/iap/frontend/src/components/Navigation.svelte
@@ -1,19 +1,20 @@
 <script>
   import {Navbar, NavBrand, NavHamburger, NavLi, NavUl} from "flowbite-svelte";
   import {STAGE} from "../const.js";
+  import {stageUrl} from "../util.js";
 
   export let current;
 </script>
 
 <Navbar let:hidden let:toggle color="form">
-  <NavBrand href="/">
+  <NavBrand href={stageUrl("/")}>
     <img src="/favicon.png" alt="9c" class="mr-3 h-6 sm:h-9"/>
     <span class="self-center whitespace-nowrap text-xl dark:text-white">9c IAP: {STAGE}</span>
   </NavBrand>
   <NavHamburger on:click={toggle}/>
   <NavUl {hidden}>
-    <NavLi href="/" active={current === "home"}>Home</NavLi>
-    <NavLi href="/receipt" active={current === "receipt"}>Receipt List</NavLi>
+    <NavLi href={stageUrl("/")} active={current === "home"}>Home</NavLi>
+    <NavLi href={stageUrl("/receipt")} active={current === "receipt"}>Receipt List</NavLi>
   </NavUl>
 </Navbar>
 

--- a/iap/frontend/src/routes/+layout.svelte
+++ b/iap/frontend/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script>
-	import '../app.postcss';
+  import '../app.postcss';
 </script>
 
-<slot />
+<slot/>

--- a/iap/frontend/src/routes/receipt/+page.svelte
+++ b/iap/frontend/src/routes/receipt/+page.svelte
@@ -12,11 +12,12 @@
   import {RECEIPT_STATUS_MAP, STAGE, STORE_MAP, TxStatus} from "../../const.js";
   import {DateTime} from "luxon";
   import Navigation from "../../components/Navigation.svelte";
+  import {stageUrl} from "../../util.js";
 
   let receiptList = [];
 
   const fetchReceiptList = async () => {
-    const resp = await fetch("/api/admin/receipt");
+    const resp = await fetch(stageUrl("/api/admin/receipt"));
     receiptList = await resp.json();
     return receiptList;
   }

--- a/iap/frontend/src/util.js
+++ b/iap/frontend/src/util.js
@@ -1,0 +1,5 @@
+import {STAGE} from "./const.js";
+
+export const stageUrl = (url) => {
+  return STAGE === "local" ? url : `/${STAGE}${url}`;
+};

--- a/iap/frontend/svelte.config.js
+++ b/iap/frontend/svelte.config.js
@@ -18,7 +18,10 @@ const config = {
 			fallback: null,
 			precompress: false,
 			strict: true
-		})
+		}),
+		prerender: {
+			crawl: false,
+		}
 	},
 
 	preprocess: [

--- a/iap/main.py
+++ b/iap/main.py
@@ -22,6 +22,7 @@ app = FastAPI(
     title="Nine Chronicles In-app Purchase Validation Service",
     description="",
     version=__VERSION__,
+    root_path=f"/{stage}" if stage != "local" else "",
     debug=settings.DEBUG,
 )
 


### PR DESCRIPTION
- FastAPI prefix is not the answer
- Adding stage prefix to svelte is the answer 
    - Skip crawlilg all generated routes when prerender stage to avoid not found error