### PR TITLE
Update apple receipt data handling

### DIFF
--- a/iap/schemas/receipt.py
+++ b/iap/schemas/receipt.py
@@ -79,7 +79,6 @@ class ReceiptSchema:
             self.payload = json.loads(self.data["Payload"])
             self.order = json.loads(self.payload["json"])
         elif self.store in (Store.APPLE, Store.APPLE_TEST):
-            # TODO: Support Apple
             pass
         elif self.store == Store.TEST:
             # No further action

--- a/iap/validator/common.py
+++ b/iap/validator/common.py
@@ -20,8 +20,10 @@ def get_order_data(receipt_data: ReceiptSchema) -> Tuple[str, Union[str, int], d
         product_id = receipt_data.order.get("productId")
         purchased_at = datetime.fromtimestamp(receipt_data.order.get("purchaseTime") // 1000)  # Remove millisecond
     elif receipt_data.store in (Store.APPLE, Store.APPLE_TEST):
-        order_id = receipt_data.data.get("transactionId")
-        product_id = receipt_data.data.get("productId")
+        order_id = receipt_data.data.get("TransactionID")
+        # product_id = receipt_data.data.get("productId")
+        # Apple does not provide productId in receipt data
+        product_id = 0
         purchased_at = datetime.utcnow()
     else:
         raise ValueError(f"{receipt_data.store.name} is unsupported store.")


### PR DESCRIPTION
- Use whole receipt data not only `transactionId`.
- Change product validation logic for apple due to input data.