### PR TITLE
Update to use custom domain

### DIFF
--- a/iap/iap_cdk_stack.py
+++ b/iap/iap_cdk_stack.py
@@ -144,13 +144,3 @@ class APIStack(Stack):
             deploy_options=_apig.StageOptions(stage_name=config.stage),
             domain_name=custom_domain,
         )
-
-        # Route53
-        # if config.stage != "development":
-        #     from aws_cdk import (aws_route53 as _r53, aws_route53_targets as _targets)
-        #
-        #     hosted_zone = _r53.PublicHostedZone.from_lookup(self, "9c-hosted-zone", domain_name="9c.gg")
-        #     record = _r53.ARecord(
-        #         self, f"{config.stage}-9c-iap-record", zone=hosted_zone,
-        #         target=_r53.RecordTarget.from_alias(_targets.ApiGateway(apig))
-        #     )

--- a/iap/main.py
+++ b/iap/main.py
@@ -22,9 +22,9 @@ app = FastAPI(
     title="Nine Chronicles In-app Purchase Validation Service",
     description="",
     version=__VERSION__,
-    root_path=f"/{stage}" if stage != "local" else "",
     debug=settings.DEBUG,
 )
+
 
 @app.middleware("http")
 def log_incoming_url(request: Request, call_next):


### PR DESCRIPTION
- FastAPI does not need root_prefix anymore
- R53 domain is not managed inside stack.