### PR TITLE
Handle item ID for season pass

### DIFF
--- a/iap/api/purchase.py
+++ b/iap/api/purchase.py
@@ -236,9 +236,9 @@ def request_product(receipt_data: ReceiptSchema, sess=Depends(session)):
             settings.REGION_NAME,
             f"{os.environ.get('STAGE')}_9c_SEASON_PASS_HOST", False
         )["Value"]
-        claim_list = [{"id": x.fungible_item_id, "amount": x.amount, "decimal_places": 0}
+        claim_list = [{"ticker": x.fungible_item_id, "amount": x.amount, "decimal_places": 0}
                       for x in product.fungible_item_list]
-        claim_list.extend([{"id": x.ticker, "amount": x.amount, "decimal_places": x.decimal_places}
+        claim_list.extend([{"ticker": x.ticker, "amount": x.amount, "decimal_places": x.decimal_places}
                            for x in product.fav_list])
         resp = requests.post(f"{season_pass_host}/api/user/upgrade",
                              json={

--- a/iap/schemas/product.py
+++ b/iap/schemas/product.py
@@ -33,6 +33,11 @@ class FungibleAssetValueSchema(BaseSchema):
     ticker: str
     amount: float
 
+    @model_validator(mode="after")
+    def make_ticker_to_name(self):
+        self.ticker = self.ticker.split("_")[-1]
+        return self
+
     class Config:
         from_attributes = True
 


### PR DESCRIPTION
- ClaimItems needs token ticker, not item/currency ID
- Cut prefix to provide item/currency ID to cilent