### PR TITLE
Faster receipt handling

### DIFF
--- a/common/shared_stack.py
+++ b/common/shared_stack.py
@@ -49,8 +49,8 @@ class SharedStack(Stack):
         self.dlq = _sqs.Queue(self, f"{config.stage}-9c-iap-dlq")
         self.q = _sqs.Queue(
             self, f"{config.stage}-9c-iap-queue",
-            dead_letter_queue=_sqs.DeadLetterQueue(max_receive_count=2, queue=self.dlq),
-            visibility_timeout=cdk_core.Duration.seconds(120),
+            dead_letter_queue=_sqs.DeadLetterQueue(max_receive_count=15, queue=self.dlq),
+            visibility_timeout=cdk_core.Duration.seconds(20),
         )
 
         # RDS

--- a/worker/worker_cdk_stack.py
+++ b/worker/worker_cdk_stack.py
@@ -106,12 +106,12 @@ class WorkerStack(Stack):
             layers=[layer],
             role=role,
             vpc=shared_stack.vpc,
-            timeout=cdk_core.Duration.seconds(120),
+            timeout=cdk_core.Duration.seconds(15),
             environment=env,
             events=[
                 _evt_src.SqsEventSource(shared_stack.q)
             ],
-            memory_size=256,
+            memory_size=1024,
             reserved_concurrent_executions=1,
         )
 

--- a/worker/worker_cdk_stack.py
+++ b/worker/worker_cdk_stack.py
@@ -126,6 +126,7 @@ class WorkerStack(Stack):
             layers=[layer],
             role=role,
             vpc=shared_stack.vpc,
+            memory_size=256,
             timeout=cdk_core.Duration.seconds(50),
             environment=env,
         )


### PR DESCRIPTION
- Lower SQS visibility timeout
- Higher SQS retry before dump to DLQ
- Higher Lambda spec to handle job