### PR TITLE
Get receipt only from order data

### DIFF
--- a/iap/schemas/receipt.py
+++ b/iap/schemas/receipt.py
@@ -60,10 +60,10 @@ class ApplePurchaseSchema(BaseSchema):
 
 @dataclass
 class ReceiptSchema:
-    store: Store
     data: Union[str, Dict, object]
-    agentAddress: str
-    avatarAddress: str
+    store: Optional[Store] = None
+    agentAddress: Optional[str] = None
+    avatarAddress: Optional[str] = None
     planetId: Union[str, PlanetID] = None
 
     # Google
@@ -87,8 +87,10 @@ class ReceiptSchema:
             pass
 
         # Reformat address to starts with `0x`
-        self.agentAddress = format_addr(self.agentAddress)
-        self.avatarAddress = format_addr(self.avatarAddress)
+        if self.agentAddress:
+            self.agentAddress = format_addr(self.agentAddress)
+        if self.avatarAddress:
+            self.avatarAddress = format_addr(self.avatarAddress)
 
         if isinstance(self.planetId, str):
             self.planetId = PlanetID(bytes(self.planetId, 'utf-8'))

--- a/iap/schemas/receipt.py
+++ b/iap/schemas/receipt.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional, Union, Dict, Any
+from typing import Optional, Union, Dict
 from uuid import UUID
 
 from pydantic import BaseModel as BaseSchema
@@ -76,6 +76,14 @@ class ReceiptSchema:
         # Parse purchase data to JSON
         if isinstance(self.data, str):
             self.data = json.loads(self.data)
+
+        if not self.store:
+            if "TransactionID" in self.data:
+                self.store = Store.APPLE
+            elif "orderId" in self.data:
+                self.store = Store.GOOGLE
+            else:
+                self.store = Store.TEST
 
         if self.store in (Store.GOOGLE, Store.GOOGLE_TEST):
             self.payload = json.loads(self.data["Payload"])


### PR DESCRIPTION
To handle data-losing case, API will allow data-only request.
If a receipt with same order id found, returns this.