### PR TITLE
Update retreat logic

### DIFF
--- a/iap/api/purchase.py
+++ b/iap/api/purchase.py
@@ -20,6 +20,7 @@ from common.utils.apple import get_jwt
 from common.utils.aws import fetch_parameter
 from common.utils.google import get_google_client
 from common.utils.receipt import PlanetID
+from exceptions import ReceiptNotFoundException
 from iap import settings
 from iap.dependencies import session
 from iap.main import logger
@@ -119,6 +120,9 @@ def request_product(receipt_data: ReceiptSchema, sess=Depends(session)):
     if prev_receipt:
         logger.debug(f"prev. receipt exists: {prev_receipt.uuid}")
         return prev_receipt
+
+    if not receipt_data.agentAddress:
+        raise ReceiptNotFoundException("", order_id)
 
     product = None
     # If prev. receipt exists, check current status and returns result

--- a/iap/schemas/receipt.py
+++ b/iap/schemas/receipt.py
@@ -78,9 +78,9 @@ class ReceiptSchema:
             self.data = json.loads(self.data)
 
         if not self.store:
-            if "TransactionID" in self.data:
+            if "AppleAppStore" in self.data.get("Store", ""):
                 self.store = Store.APPLE
-            elif "orderId" in self.data:
+            elif "GooglePlay" in self.data.get("Store", ""):
                 self.store = Store.GOOGLE
             else:
                 self.store = Store.TEST


### PR DESCRIPTION
- Get store from `Store` field of request data
- Returns no receipt found and no user data provided.
    - This is fully lost case.