### PR TITLE
Apply theori security report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,11 @@ jobs:
     with:
       environment: ${{ github.ref == 'refs/heads/main' && 'mainnet' || (startsWith(github.ref, 'refs/heads/release') && 'internal' || 'development') }}
     secrets:
+      APPLE_CREDENTIAL: ${{ secrets.APPEL_CREDENTIAL }}
+      APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
+      APPLE_ISSUER_ID: ${{ secrets.APPEL_ISSUER_ID }}
+      GOOGLE_CREDENTIAL: ${{ secrets.GOOGLE_CREDENTIAL }}
+      SEASON_PASS_JWT_SECRET: ${{ secrets.SEASON_PASS_JWT_SECRET }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   build_frontend:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,9 @@ jobs:
     with:
       environment: ${{ github.ref == 'refs/heads/main' && 'mainnet' || (startsWith(github.ref, 'refs/heads/release') && 'internal' || 'development') }}
     secrets:
-      APPLE_CREDENTIAL: ${{ secrets.APPEL_CREDENTIAL }}
+      APPLE_CREDENTIAL: ${{ secrets.APPLE_CREDENTIAL }}
       APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
-      APPLE_ISSUER_ID: ${{ secrets.APPEL_ISSUER_ID }}
+      APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
       GOOGLE_CREDENTIAL: ${{ secrets.GOOGLE_CREDENTIAL }}
       SEASON_PASS_JWT_SECRET: ${{ secrets.SEASON_PASS_JWT_SECRET }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,10 +81,12 @@ jobs:
           DB_URI: "postgresql://github_actions:f8bf4c09239@localhost/iap"
           GOOGLE_PACKAGE_NAME: ${{ vars.GOOGLE_PACKAGE_NAME }}
           GOOGLE_CREDENTIAL: ${{ secrets.GOOGLE_CREDENTIAL }}
+          APPLE_VALIDATION_URL : ${{ vars.APPLE_VALIDATION_URL }}
           APPLE_CREDENTIAL: ${{ secrets.APPEL_CREDENTIAL }}
           APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
           APPLE_ISSUER_ID: ${{ secrets.APPEL_ISSUER_ID }}
           APPLE_BUNDLE_ID: ${{ vars.APPLE_BUNDLE_ID }}
+          SEASON_PASS_JWT_SECRET: ${{ secrets.SEASON_PASS_JWT_SECRET }}
         run: |
           poetry run pytest tests
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,9 +82,9 @@ jobs:
           GOOGLE_PACKAGE_NAME: ${{ vars.GOOGLE_PACKAGE_NAME }}
           GOOGLE_CREDENTIAL: ${{ secrets.GOOGLE_CREDENTIAL }}
           APPLE_VALIDATION_URL : ${{ vars.APPLE_VALIDATION_URL }}
-          APPLE_CREDENTIAL: ${{ secrets.APPEL_CREDENTIAL }}
+          APPLE_CREDENTIAL: ${{ secrets.APPLE_CREDENTIAL }}
           APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
-          APPLE_ISSUER_ID: ${{ secrets.APPEL_ISSUER_ID }}
+          APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
           APPLE_BUNDLE_ID: ${{ vars.APPLE_BUNDLE_ID }}
           SEASON_PASS_JWT_SECRET: ${{ secrets.SEASON_PASS_JWT_SECRET }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,16 @@ on:
         required: true
         type: string
     secrets:
+      APPLE_CREDENTIAL:
+        required: true
+      APPLE_KEY_ID:
+        required: true
+      APPLE_ISSUER_ID:
+        required: true
+      GOOGLE_CREDENTIAL:
+        required: true
+      SEASON_PASS_JWT_SECRET:
+        required: true
       SLACK_WEBHOOK_URL:
         required: true
 
@@ -65,6 +75,16 @@ jobs:
           popd
 
       - name: Run test
+        env:
+          STAGE: test
+          REGION_NAME: ${{ vars.REGION_NAME }}
+          DB_URI: "postgresql://github_actions:f8bf4c09239@localhost/iap"
+          GOOGLE_PACKAGE_NAME: ${{ vars.GOOGLE_PACKAGE_NAME }}
+          GOOGLE_CREDENTIAL: ${{ secrets.GOOGLE_CREDENTIAL }}
+          APPLE_CREDENTIAL: ${{ secrets.APPEL_CREDENTIAL }}
+          APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
+          APPLE_ISSUER_ID: ${{ secrets.APPEL_ISSUER_ID }}
+          APPLE_BUNDLE_ID: ${{ vars.APPLE_BUNDLE_ID }}
         run: |
           poetry run pytest tests
 

--- a/iap/settings/__init__.py
+++ b/iap/settings/__init__.py
@@ -21,22 +21,29 @@ if os.path.exists(os.path.join("iap", "settings", f"{stage}.py")):
     config = Config(environ=envs)
 else:
     config = Config(environ=os.environ)
-    db_password = fetch_secrets(os.environ.get("REGION_NAME"), os.environ.get("SECRET_ARN"))["password"]
-    google_credential = fetch_parameter(
-        os.environ.get("REGION_NAME"),
-        f"{stage}_9c_IAP_GOOGLE_CREDENTIAL",
-        True
-    )["Value"]
-    apple_credential = fetch_parameter(
-        os.environ.get("REGION_NAME"),
-        f"{stage}_9c_IAP_APPLE_CREDENTIAL",
-        True
-    )["Value"]
-    season_pass_jwt_secret = fetch_parameter(
-        os.environ.get("REGION_NAME"),
-        f"{stage}_9c_IAP_SEASON_PASS_JWT_SECRET",
-        True
-    )["Value"]
+    if os.environ.get("SECRET_ARN"):
+        db_password = fetch_secrets(os.environ.get("REGION_NAME"), os.environ.get("SECRET_ARN"))["password"]
+
+    if os.environ.get(f"{stage}_9c_IAP_GOOGLE_CREDENTIAL"):
+        google_credential = fetch_parameter(
+            os.environ.get("REGION_NAME"),
+            f"{stage}_9c_IAP_GOOGLE_CREDENTIAL",
+            True
+        )["Value"]
+
+    if os.environ.get(f"{stage}_9c_IAP_APPLE_CREDENTIAL"):
+        apple_credential = fetch_parameter(
+            os.environ.get("REGION_NAME"),
+            f"{stage}_9c_IAP_APPLE_CREDENTIAL",
+            True
+        )["Value"]
+
+    if os.environ.get(f"{stage}_9c_IAP_SEASON_PASS_JWT_SECRET"):
+        season_pass_jwt_secret = fetch_parameter(
+            os.environ.get("REGION_NAME"),
+            f"{stage}_9c_IAP_SEASON_PASS_JWT_SECRET",
+            True
+        )["Value"]
 
 # Prepare settings
 DEBUG = config("DEBUG", cast=bool, default=False)

--- a/iap/validator/apple.py
+++ b/iap/validator/apple.py
@@ -1,0 +1,32 @@
+import time
+import urllib.parse
+from typing import Tuple, Optional
+
+import jwt
+import requests
+
+from common import logger
+from common.utils.apple import get_jwt
+from iap import settings
+from iap.schemas.receipt import ApplePurchaseSchema
+
+
+def validate_apple(tx_id: str) -> Tuple[bool, str, Optional[ApplePurchaseSchema]]:
+    headers = {
+        "Authorization": f"Bearer {get_jwt(settings.APPLE_CREDENTIAL, settings.APPLE_BUNDLE_ID, settings.APPLE_KEY_ID, settings.APPLE_ISSUER_ID)}"
+    }
+    encoded_tx_id = urllib.parse.quote_plus(tx_id)
+    resp = requests.get(settings.APPLE_VALIDATION_URL.format(transactionId=encoded_tx_id), headers=headers)
+    if resp.status_code != 200:
+        time.sleep(1)
+        resp = requests.get(settings.APPLE_VALIDATION_URL.format(transactionId=encoded_tx_id), headers=headers)
+        if resp.status_code != 200:
+            return False, f"Purchase state of this receipt is not valid: {resp.text}", None
+    try:
+        data = jwt.decode(resp.json()["signedTransactionInfo"], options={"verify_signature": False})
+        logger.debug(data)
+        schema = ApplePurchaseSchema(**data)
+    except:
+        return False, f"Malformed apple transaction data for {encoded_tx_id}", None
+    else:
+        return True, "", schema

--- a/iap/validator/google.py
+++ b/iap/validator/google.py
@@ -1,0 +1,26 @@
+from typing import Tuple, Optional
+
+from common import logger
+from common.enums import GooglePurchaseState
+from common.utils.google import get_google_client
+from iap import settings
+from iap.schemas.receipt import GooglePurchaseSchema
+
+
+def validate_google(order_id: str, sku: str, token: str) -> Tuple[bool, str, Optional[GooglePurchaseSchema]]:
+    client = get_google_client(settings.GOOGLE_CREDENTIAL)
+    try:
+        resp = GooglePurchaseSchema(
+            **(client.purchases().products()
+               .get(packageName=settings.GOOGLE_PACKAGE_NAME, productId=sku, token=token)
+               .execute())
+        )
+        if resp.purchaseState != GooglePurchaseState.PURCHASED:
+            return False, f"Purchase state of this receipt is not valid: {resp.purchaseState.name}", resp
+        if resp.orderId != order_id:
+            return False, f"Order ID mismatch from request and token: {order_id} :: {resp.orderId}", resp
+        return True, "", resp
+
+    except Exception as e:
+        logger.warning(e)
+        return False, f"Error occurred validating google receipt: {e}", None

--- a/tests/iap/api/test_purchase.py
+++ b/tests/iap/api/test_purchase.py
@@ -1,0 +1,40 @@
+import pytest
+
+from iap.validator.apple import validate_apple
+from iap.validator.google import validate_google
+
+# Both purchases are test purchase.
+TEST_APPLE_ORDER_ID = '2000000458219693'
+TEST_GOOGLE_ORDER_DATA = {
+    'orderId': 'GPA.3392-3387-9900-22421',
+    'productId': 'g_single_golddust07',
+    'purchaseToken': 'kgdnggbbfpmihiefjmfcgcnc.AO-J1OwoOqlGYPprvDHfRbKNDdvVnsLux3XJldQUIdjsP1lvVAxNmgqofJPgHboMoAaTqL8TjTKMlwlwGxcWVoZLkqbr5VAb6aqXFdZ17_zTuS9tDujCQNqYo6J_oAu_axlHBBCxgUtO',
+}
+TEST_GOOGLE_FAKE_ORDER_ID = "FKE.1234-1234-1234-00000"
+
+
+def test_apple_verify_success():
+    success, message, data = validate_apple(TEST_APPLE_ORDER_ID)
+    assert success is True
+
+
+@pytest.mark.parametrize("order_id", [f"{TEST_APPLE_ORDER_ID}#1", f"{TEST_APPLE_ORDER_ID}&1"])
+def test_apple_verify_failure_with_fragment(order_id):
+    success, message, data = validate_apple(order_id)
+    assert success is False
+
+
+def test_google_verify_success():
+    success, message, data = validate_google(TEST_GOOGLE_ORDER_DATA["orderId"],
+                                             TEST_GOOGLE_ORDER_DATA["productId"],
+                                             TEST_GOOGLE_ORDER_DATA["purchaseToken"]
+                                             )
+    assert success is True
+
+
+def test_google_verify_failure_with_fake_order_id():
+    success, message, data = validate_google(TEST_GOOGLE_FAKE_ORDER_ID,
+                                             TEST_GOOGLE_ORDER_DATA["productId"],
+                                             TEST_GOOGLE_ORDER_DATA["purchaseToken"],
+                                             )
+    assert success is False


### PR DESCRIPTION
- URLencode Apple order ID to prevent order ID reuse with extra parameter
    - `12341234#1` 같은게 작동하고 있어서 이를 urlencode 해서 % encode해 방어
- Cross check order id form request and from token validation data
    - request 에 있는 것과 token 검증에서 나온 order ID 가 동일한지 추가 체크
- Move try-except block inside loop to continue to process next message
    - 하나의 처리가 실패해도 다음으로 넘어갈 수 있도록 변경

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206261576279892