### PR TITLE
Change GQL schema to apply libplanet 4.0

### DIFF
--- a/worker/worker/golden_dust_by_ncg.py
+++ b/worker/worker/golden_dust_by_ncg.py
@@ -375,10 +375,10 @@ def track_tx(event, context):
                     client.ds.TransactionHeadlessQuery.transactionResult.args(
                         txId=tx[0]
                     ).select(
-                        client.ds.TxResultType.txStatus,
-                        client.ds.TxResultType.blockIndex,
-                        client.ds.TxResultType.blockHash,
-                        client.ds.TxResultType.exceptionNames,
+                        client.ds.TxResult.txStatus,
+                        client.ds.TxResult.blockIndex,
+                        client.ds.TxResult.blockHash,
+                        client.ds.TxResult.exceptionNames,
                     )
                 )
             )

--- a/worker/worker/tracker.py
+++ b/worker/worker/tracker.py
@@ -33,10 +33,10 @@ def process(tx_id: str) -> Tuple[str, Optional[TxStatus], Optional[str]]:
                 client.ds.TransactionHeadlessQuery.transactionResult.args(
                     txId=tx_id
                 ).select(
-                    client.ds.TxResultType.txStatus,
-                    client.ds.TxResultType.blockIndex,
-                    client.ds.TxResultType.blockHash,
-                    client.ds.TxResultType.exceptionNames,
+                    client.ds.TxResult.txStatus,
+                    client.ds.TxResult.blockIndex,
+                    client.ds.TxResult.blockHash,
+                    client.ds.TxResult.exceptionNames,
                 )
             )
         )


### PR DESCRIPTION
To apply libplanet 4.0, change GQL schema from `TxResultType` to `TxResult`