### PR TITLE
Get token balance for IAP

### DIFF
--- a/worker/worker/status_monitor.py
+++ b/worker/worker/status_monitor.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import sessionmaker, scoped_session
 
 from common import logger
 from common._graphql import GQL
+from common.consts import GQL_DICT
 from common.enums import ReceiptStatus, TxStatus
 from common.models.receipt import Receipt
 from common.utils.aws import fetch_parameter, fetch_secrets
@@ -17,8 +18,8 @@ STAGE = os.environ.get("STAGE")
 DB_URI = os.environ.get("DB_URI")
 db_password = fetch_secrets(os.environ.get("REGION_NAME"), os.environ.get("SECRET_ARN"))["password"]
 DB_URI = DB_URI.replace("[DB_PASSWORD]", db_password)
-CURRENT_PLANET = PlanetID.ODIN if os.environ.get("STAGE") == "mainnet" else PlanetID.ODIN_INTERNAL
-GQL_URL = f"{os.environ.get('HEADLESS')}/graphql"
+PLANET_LIST = (PlanetID.ODIN, PlanetID.HEIMDALL) if STAGE == "mainnet" \
+    else (PlanetID.ODIN_INTERNAL, PlanetID.HEIMDALL_INTERNAL)
 IAP_ALERT_WEBHOOK_URL = os.environ.get("IAP_ALERT_WEBHOOK_URL")
 IAP_GARAGE_WEBHOOK_URL = os.environ.get("IAP_GARAGE_WEBHOOK_URL")
 HEADLESS_GQL_JWT_SECRET = fetch_parameter(
@@ -139,43 +140,60 @@ def check_no_tx(sess):
     send_message(IAP_ALERT_WEBHOOK_URL, "[NineChronicles.IAP] No Tx. Create Receipt Report", msg)
 
 
-def check_garage():
+def check_token_balance(url: str):
     """Report IAP Garage stock"""
-    gql = GQL(jwt_secret=HEADLESS_GQL_JWT_SECRET)
-    query = """{
-      stateQuery {
-        garages(
-          agentAddr: "0xCb75C84D76A6f97A2d55882Aea4436674c288673",
-          currencyTickers: [
-            "CRYSTAL", "RUNE_GOLDENLEAF",
-            "SOULSTONE_1001", "SOULSTONE_1002", "SOULSTONE_1003", "SOULSTONE_1004",
-          ]
-          fungibleItemIds: [
-            "3991e04dd808dc0bc24b21f5adb7bf1997312f8700daf1334bf34936e8a0813a",  # Hourglass (400000)
-            "00dfffe23964af9b284d121dae476571b7836b8d9e2e5f510d92a840fecc64fe",  # AP Potion (500000)
-            "f8faf92c9c0d0e8e06694361ea87bfc8b29a8ae8de93044b98470a57636ed0e0"   # Golden Dust (600201)
-            "08f566bb43570aad34c1790901f824dd5609db880afebd5382fcec054203d92a",  # Ruby Dust (600202)
-            "48e50ecd6d1aa2689fd349c1f0611e6cc1e9c4c74ec4de9d4637ec7b78617308",  # Golden Meat (800202)
-            "1a755098a2bc0659a063107df62e2ff9b3cdaba34d96b79519f504b996f53820",  # Silver Dust (800201)
-          ]
-        ) {
-          garageBalances { currency { ticker minters decimalPlaces } quantity }
-          fungibleItemGarages { fungibleItemId item {itemSubType} count }
-        }
-      }
-    }"""
+    gql = GQL(url, jwt_secret=HEADLESS_GQL_JWT_SECRET)
+    query = """
+query balanceQuery(
+  $address: Address! = "0xCb75C84D76A6f97A2d55882Aea4436674c288673"
+) {
+  stateQuery {
+    hourglass: balance (
+      address: $address,
+      currency: {ticker: "Item_NT_400000", decimalPlaces: 0, minters: [], }
+    ) { currency {ticker} quantity }
+    APPotion: balance (
+      address: $address,
+      currency: {ticker: "Item_NT_500000", decimalPlaces: 0, minters: [], }
+    ) { currency {ticker} quantity }
+    GoldenDust: balance (
+      address: $address,
+      currency: {ticker: "Item_NT_600201", decimalPlaces: 0, minters: [], }
+    ) { currency {ticker} quantity }
+    RubyDust: balance (
+      address: $address,
+      currency: {ticker: "Item_NT_600202", decimalPlaces: 0, minters: [], }
+    ) { currency {ticker} quantity }
+    EmeraldDust: balance (
+      address: $address,
+      currency: {ticker: "Item_NT_600203", decimalPlaces: 0, minters: [], }
+    ) { currency {ticker} quantity }
+    SilverDust: balance (
+      address: $address,
+      currency: {ticker: "Item_NT_800201", decimalPlaces: 0, minters: [], }
+    ) { currency {ticker} quantity }
+    Crystal: balance (
+      address: $address,
+      currency: {ticker: "FAV__CRYSTAL", decimalPlaces: 18, minters: [], }
+    ) { currency {ticker} quantity }
+    GoldenLeafRune: balance (
+      address: $address,
+      currency: {ticker: "FAV__RUNE_GOLDENLEAF", decimalPlaces: 0, minters: [], }
+    ) { currency {ticker} quantity }
+    CriRune: balance (
+      address: $address,
+      currency: {ticker: "FAV__RUNESTONE_CRI", decimalPlaces: 0, minters: [], }
+    ) { currency {ticker} quantity }
+  }
+}"""
 
-    resp = requests.post(GQL_URL, json={"query": query}, headers={"Authorization": f"Bearer {gql.create_token()}"})
-    data = resp.json()["data"]["stateQuery"]["garages"]
-    fav_data = data["garageBalances"]
-    item_data = data["fungibleItemGarages"]
+    resp = requests.post(url, json={"query": query}, headers={"Authorization": f"Bearer {gql.create_token()}"})
+    data = resp.json()["data"]["stateQuery"]
 
     result_dict = {}
 
-    for fav in fav_data:
-        result_dict[fav["currency"]["ticker"]] = fav["quantity"].split(".")[0]
-    for item in item_data:
-        result_dict[FUNGIBLE_DICT[item["fungibleItemId"]]] = item["count"]
+    for name, balance in data.items():
+        result_dict[f"{name} ({balance['currency']['ticker']})"] = balance['quantity']
 
     msg = []
     for key in VIEW_ORDER:
@@ -190,7 +208,8 @@ def check_garage():
 def handle(event, context):
     sess = scoped_session(sessionmaker(bind=engine))
     if datetime.utcnow().hour == 3 and datetime.now().minute == 0:  # 12:00 KST
-        check_garage()
+        for planet_id in PLANET_LIST:
+            check_token_balance(GQL_DICT[planet_id])
 
     try:
         check_invalid_receipt(sess)
@@ -203,7 +222,8 @@ def handle(event, context):
 
 if __name__ == "__main__":
     sess = scoped_session(sessionmaker(bind=engine))
-    check_garage()
+    for planet_id in PLANET_LIST:
+        check_token_balance(GQL_DICT[planet_id])
     check_invalid_receipt(sess)
     check_halt_tx(sess)
     check_tx_failure(sess)

--- a/worker/worker_cdk_stack.py
+++ b/worker/worker_cdk_stack.py
@@ -191,8 +191,8 @@ class WorkerStack(Stack):
         if config.stage == "mainnet":
             ten_minute_event_rule.add_target(_event_targets.LambdaFunction(status_monitor))
         # If you want to test monitor in internal, uncomment following statement
-        # else:
-        #     hourly_event_rule.add_target(_event_targets.LambdaFunction(status_monitor))
+        else:
+            hourly_event_rule.add_target(_event_targets.LambdaFunction(status_monitor))
 
         # IAP Voucher
         voucher_env = deepcopy(env)


### PR DESCRIPTION
From 2.0.0, the IAP action is changed from `UnloadFromMyGarages` to `ClaimItems` so we need to track token balance instead of garage.