### PR TITLE
Add retry API just with receipt data

### DIFF
--- a/iap/api/purchase.py
+++ b/iap/api/purchase.py
@@ -22,7 +22,7 @@ from iap import settings
 from iap.dependencies import session
 from iap.exceptions import ReceiptNotFoundException, InsufficientUserDataException
 from iap.main import logger
-from iap.schemas.receipt import ReceiptSchema, ReceiptDetailSchema, FreeReceiptSchema, PurchaseRetrySchema
+from iap.schemas.receipt import ReceiptSchema, ReceiptDetailSchema, FreeReceiptSchema, SimpleReceiptSchema
 from iap.utils import create_season_pass_jwt, get_purchase_count
 from iap.validator.apple import validate_apple
 from iap.validator.common import get_order_data
@@ -119,7 +119,7 @@ def check_purchase_limit(sess, receipt: Receipt, product: Product, limit_type: s
 
 
 @router.post("/retry", response_model=ReceiptDetailSchema)
-def retry_product(receipt_data: PurchaseRetrySchema,
+def retry_product(receipt_data: SimpleReceiptSchema,
                   x_iap_packagename: Annotated[PackageName | None, Header()] = PackageName.NINE_CHRONICLES_M,
                   sess=Depends(session)
                   ):

--- a/iap/api/purchase.py
+++ b/iap/api/purchase.py
@@ -20,9 +20,9 @@ from common.utils.aws import fetch_parameter
 from common.utils.receipt import PlanetID
 from iap import settings
 from iap.dependencies import session
-from iap.exceptions import ReceiptNotFoundException
+from iap.exceptions import ReceiptNotFoundException, InsufficientUserDataException
 from iap.main import logger
-from iap.schemas.receipt import ReceiptSchema, ReceiptDetailSchema, FreeReceiptSchema
+from iap.schemas.receipt import ReceiptSchema, ReceiptDetailSchema, FreeReceiptSchema, PurchaseRetrySchema
 from iap.utils import create_season_pass_jwt, get_purchase_count
 from iap.validator.apple import validate_apple
 from iap.validator.common import get_order_data
@@ -116,6 +116,55 @@ def check_purchase_limit(sess, receipt: Receipt, product: Product, limit_type: s
         raise_error(sess, receipt, ValueError(f"{limit_type.capitalize()} purchase limit exceeded."))
 
     return receipt
+
+
+@router.post("/retry", response_model=ReceiptDetailSchema)
+def retry_product(receipt_data: PurchaseRetrySchema,
+                  x_iap_packagename: Annotated[PackageName | None, Header()] = PackageName.NINE_CHRONICLES_M,
+                  sess=Depends(session)
+                  ):
+    """
+    # Purchase retry
+    ---
+
+    ** Retry from client's pending IAP purchase data.**
+    """
+    order_id, product_id, purchased_at = get_order_data(receipt_data)
+    prev_receipt = sess.scalar(
+        select(Receipt).where(Receipt.store == receipt_data.store, Receipt.order_id == order_id)
+    )
+
+    # Cannot handle missing receipt
+    if not prev_receipt:
+        raise ReceiptNotFoundException("", order_id)
+
+    # Already handled
+    if prev_receipt.tx_status is not None:
+        logger.info(f"[Retry] {order_id} has already been handled :: {prev_receipt.uuid}")
+        return prev_receipt
+
+    # Insufficient user data
+    empty_data = []
+    if not prev_receipt.planet_id:
+        empty_data.append("planet_id")
+    if not prev_receipt.agent_addr:
+        empty_data.append("agent_addr")
+    if not prev_receipt.avatar_addr:
+        empty_data.append("avatar_addr")
+
+    if empty_data:
+        raise InsufficientUserDataException(prev_receipt.uuid, order_id, empty_data)
+
+    # Can do retry
+    receipt_schema = ReceiptSchema(
+        data=receipt_data.data,
+        store=receipt_data.store,
+        agentAddress=prev_receipt.agent_addr,
+        avatarAddress=prev_receipt.avatar_addr,
+        planetId=prev_receipt.planet_id
+    )
+    return request_product(receipt_schema, x_iap_packagename=x_iap_packagename)
+
 
 
 @router.post("/request", response_model=ReceiptDetailSchema)

--- a/iap/exceptions.py
+++ b/iap/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional
+from typing import Union, Optional, List
 from uuid import uuid4
 
 
@@ -14,3 +14,13 @@ class ReceiptNotFoundException(Exception):
         elif self.order_id:
             return f"Receipt {self.order_id} not found."
 
+
+class InsufficientUserDataException(Exception):
+    def __init__(self, receipt_uuid: Union[str, uuid4], order_id: Optional[str], empty_data: List[str]):
+        super().__init__()
+        self.receipt_uuid = receipt_uuid
+        self.order_id = order_id
+        self.empty_data = empty_data
+
+    def __str__(self):
+        return f"Receipt {self.receipt_uuid} :: {self.order_id} has insufficient user data: {self.empty_data}"

--- a/iap/schemas/receipt.py
+++ b/iap/schemas/receipt.py
@@ -79,6 +79,12 @@ class FreeReceiptSchema:
 
 
 @dataclass
+class PurchaseRetrySchema:
+    data: Union[str, Dict, object]
+    store: Optional[Store] = None
+
+
+@dataclass
 class ReceiptSchema:
     data: Union[str, Dict, object]
     store: Optional[Store] = None

--- a/iap/schemas/receipt.py
+++ b/iap/schemas/receipt.py
@@ -79,18 +79,9 @@ class FreeReceiptSchema:
 
 
 @dataclass
-class PurchaseRetrySchema:
+class SimpleReceiptSchema:
     data: Union[str, Dict, object]
     store: Optional[Store] = None
-
-
-@dataclass
-class ReceiptSchema:
-    data: Union[str, Dict, object]
-    store: Optional[Store] = None
-    agentAddress: Optional[str] = None
-    avatarAddress: Optional[str] = None
-    planetId: Union[str, PlanetID] = None
 
     # Google
     payload: Optional[Dict] = None
@@ -119,6 +110,16 @@ class ReceiptSchema:
         elif self.store == Store.TEST:
             # No further action
             pass
+
+
+@dataclass
+class ReceiptSchema(SimpleReceiptSchema):
+    agentAddress: Optional[str] = None
+    avatarAddress: Optional[str] = None
+    planetId: Union[str, PlanetID] = None
+
+    def __post_init__(self):
+        super().__post_init__()
 
         # Reformat address to starts with `0x`
         if self.agentAddress:

--- a/iap/validator/common.py
+++ b/iap/validator/common.py
@@ -2,10 +2,10 @@ from datetime import datetime
 from typing import Tuple, Union
 
 from common.enums import Store
-from iap.schemas.receipt import ReceiptSchema
+from iap.schemas.receipt import ReceiptSchema, PurchaseRetrySchema
 
 
-def get_order_data(receipt_data: ReceiptSchema) -> Tuple[str, Union[str, int], datetime]:
+def get_order_data(receipt_data: Union[ReceiptSchema, PurchaseRetrySchema]) -> Tuple[str, Union[str, int], datetime]:
     """
     Returns order_id, product_id, purchased_at from receipt data by store
     :param receipt_data:

--- a/iap/validator/common.py
+++ b/iap/validator/common.py
@@ -2,10 +2,10 @@ from datetime import datetime
 from typing import Tuple, Union
 
 from common.enums import Store
-from iap.schemas.receipt import ReceiptSchema, PurchaseRetrySchema
+from iap.schemas.receipt import ReceiptSchema, SimpleReceiptSchema
 
 
-def get_order_data(receipt_data: Union[ReceiptSchema, PurchaseRetrySchema]) -> Tuple[str, Union[str, int], datetime]:
+def get_order_data(receipt_data: Union[ReceiptSchema, SimpleReceiptSchema]) -> Tuple[str, Union[str, int], datetime]:
     """
     Returns order_id, product_id, purchased_at from receipt data by store
     :param receipt_data:


### PR DESCRIPTION
Client requests retry when pending purchases found in device.
To handle this, add new retry API.

### Caveat
- This API only can handle formerly requested to IAP service which can found in IAP DB.