### PR TITLE
과도하게 울리는 알람 비활성화

### DIFF
--- a/worker/worker/status_monitor.py
+++ b/worker/worker/status_monitor.py
@@ -97,8 +97,9 @@ def check_halt_tx(sess):
     ).scalar()
 
     msg = []
-    msg.append(create_block(f"<@U03DRL8R1FE> <@UCKUGBH37> Tx. Invalid Receipt Report :: {tx_halt_receipt_list}"))
-    send_message(IAP_ALERT_WEBHOOK_URL, "[NineChronicles.IAP] Tx. Invalid Receipt Report", msg)
+    if tx_halt_receipt_list > 0:
+        msg.append(create_block(f"<@U03DRL8R1FE> <@UCKUGBH37> Tx. Invalid Receipt Report :: {tx_halt_receipt_list}"))
+        send_message(IAP_ALERT_WEBHOOK_URL, "[NineChronicles.IAP] Tx. Invalid Receipt Report", msg)
 
 
 def check_no_tx(sess):

--- a/worker/worker/status_monitor.py
+++ b/worker/worker/status_monitor.py
@@ -69,7 +69,7 @@ def check_invalid_receipt(sess):
     ).scalar()
 
     msg = []
-    msg.append(create_block(f"<@U03DRL8R1FE> <@UCKUGBH37>Non-Valid Receipt Report :: {invalid_list}"))
+    msg.append(create_block(f"Non-Valid Receipt Report :: {invalid_list}"))
 
     send_message(IAP_ALERT_WEBHOOK_URL, "[NineChronicles.IAP] Non-Valid Receipt Report", msg)
 
@@ -80,7 +80,6 @@ def check_tx_failure(sess):
 
     msg = []
     if len(tx_failed_receipt_list) > 0:
-        msg.append(create_block(f"<@U03DRL8R1FE> <@UCKUGBH37>"))
         for receipt in tx_failed_receipt_list:
           msg.append(create_block(
               f"ID {receipt.id} :: {receipt.uuid} :: {receipt.tx_status.name}\nTx. ID: {receipt.tx_id}"


### PR DESCRIPTION
람다에 임시배포해둔 코드를 적용합니다.
- Tx처리가 안되는 알람을 존재할때만 보내도록 처리합니다.
- 영수증 상태 알람은 원인조사까지 멘션을 비활성화합니다.