### PR TITLE
handle queue pool error & avoid receipt null case

### DIFF
--- a/apps/worker/app/tasks/send_product_task.py
+++ b/apps/worker/app/tasks/send_product_task.py
@@ -29,7 +29,7 @@ def create_tx(sess: Session, account: Account, receipt: Receipt) -> bytes:
         return bytes.fromhex(receipt.tx)
 
     logger.debug(f"Looking for product with ID: {receipt.product_id} for receipt: {receipt.uuid}")
-    logger.debug(f"Session state: active={sess.is_active}, in_transaction={sess.in_transaction()}")
+    logger.debug(f"Session state: active={sess.is_active}")
 
     # First try a simple query without joins to see if the product exists
     simple_product = sess.scalar(select(Product).where(Product.id == receipt.product_id))

--- a/apps/worker/app/tasks/tracker.py
+++ b/apps/worker/app/tasks/tracker.py
@@ -18,7 +18,14 @@ logger = structlog.get_logger(__name__)
 
 LIMIT = 50
 
-engine = create_engine(config.pg_dsn, pool_size=5, max_overflow=5)
+engine = create_engine(
+    config.pg_dsn,
+    pool_size=10,  # 기본 연결 수 증가
+    max_overflow=20,  # 오버플로우 연결 수 증가
+    pool_timeout=60,  # 연결 타임아웃 증가
+    pool_recycle=3600,  # 연결 재사용 시간 (1시간)
+    pool_pre_ping=True  # 연결 상태 확인
+)
 
 # GQL 클라이언트 캐시
 _gql_clients: Dict[str, GQL] = {}
@@ -85,39 +92,45 @@ def track_tx(self) -> str:
     db_start = time.time()
     sess = scoped_session(sessionmaker(bind=engine))
 
-    query_start = time.time()
-    receipt_list = sess.scalars(
-        select(Receipt)
-        .where(
-            Receipt.status == ReceiptStatus.VALID,
-            Receipt.tx_status.in_((TxStatus.STAGED, TxStatus.INVALID)),
-        )
-        .order_by(Receipt.id)
-        .limit(LIMIT)
-    ).fetchall()
+    try:
+        query_start = time.time()
+        receipt_list = sess.scalars(
+            select(Receipt)
+            .where(
+                Receipt.status == ReceiptStatus.VALID,
+                Receipt.tx_status.in_((TxStatus.STAGED, TxStatus.INVALID)),
+            )
+            .order_by(Receipt.id)
+            .limit(LIMIT)
+        ).fetchall()
 
-    result = defaultdict(list)
-    for receipt in receipt_list:
-        tx_id, tx_status, msg = process(
-            config.converted_gql_url_map[receipt.planet_id], receipt.tx_id
-        )
-        if tx_status is not None:
-            result[tx_status.name].append(tx_id)
-            receipt.tx_status = tx_status
-        if msg:
-            receipt.msg = "\n".join([receipt.msg or "", msg])
-        sess.add(receipt)
+        result = defaultdict(list)
+        for receipt in receipt_list:
+            tx_id, tx_status, msg = process(
+                config.converted_gql_url_map[receipt.planet_id], receipt.tx_id
+            )
+            if tx_status is not None:
+                result[tx_status.name].append(tx_id)
+                receipt.tx_status = tx_status
+            if msg:
+                receipt.msg = "\n".join([receipt.msg or "", msg])
+            sess.add(receipt)
 
-    commit_start = time.time()
-    sess.commit()
+        commit_start = time.time()
+        sess.commit()
 
-    logger.info(f"{len(receipt_list)} transactions are found to track status")
-    for status, tx_list in result.items():
-        if status is None:
-            logger.error(f"{len(tx_list)} transactions are not able to track.")
-            for tx in tx_list:
-                logger.error(tx)
-        elif status == TxStatus.STAGED:
-            logger.info(f"{len(tx_list)} transactions are still staged.")
-        else:
-            logger.info(f"{len(tx_list)} transactions are changed to {status}")
+        logger.info(f"{len(receipt_list)} transactions are found to track status")
+        for status, tx_list in result.items():
+            if status is None:
+                logger.error(f"{len(tx_list)} transactions are not able to track.")
+                for tx in tx_list:
+                    logger.error(tx)
+            elif status == TxStatus.STAGED:
+                logger.info(f"{len(tx_list)} transactions are still staged.")
+            else:
+                logger.info(f"{len(tx_list)} transactions are changed to {status}")
+
+    finally:
+        if sess is not None:
+            sess.close()
+            logger.debug("track_tx session closed successfully")


### PR DESCRIPTION
- db에는 연결된 릴레이션십의 레코드가 존재하나 task내부에서 해당 조건의 receipt를 못찾는 문제 방지
- task처리중 오류나면 session이 정리안되는 문제 해결