### PR TITLE
Exclude season-pass SKUs from product-sales stats (PLD-1357)

### DIFF
--- a/apps/api/app/api/admin.py
+++ b/apps/api/app/api/admin.py
@@ -13,7 +13,7 @@ from shared.models.product import FungibleAssetProduct, FungibleItemProduct, Pri
 from shared.models.receipt import Receipt
 from shared.schemas.product import ProductSchema
 from shared.schemas.receipt import FullReceiptSchema, RefundedReceiptSchema
-from sqlalchemy import Date, and_, desc, func, select
+from sqlalchemy import Date, and_, desc, func, or_, select
 from sqlalchemy.orm import joinedload
 
 from app.config import config
@@ -1135,6 +1135,12 @@ _MAINNET_PLANET_NAMES = {
     PlanetID.HEIMDALL.value: "HEIMDALL",
 }
 
+# SKUs matching this pattern are season-pass style purchases where actual
+# token grants are performed by the SeasonPass service (see purchase.py:
+# `if "pass" in product.google_sku`), not by IAP. Including them here would
+# double-count against SeasonPass's own reward-claims stats.
+_SEASON_PASS_SKU_ILIKE = "%pass%"
+
 
 @router.get("/stats/product-sales", response_model=ProductSalesResponse)
 def get_product_sales(
@@ -1149,6 +1155,9 @@ def get_product_sales(
     grant_items tx와 동일한 ticker 포맷(FAV__{ticker}, Item_NT_{sheet_item_id})으로
     플래닛별 토큰 총 지급량을 반환합니다.
     날짜 필터는 UTC 기준이며, DB의 created_at(KST)을 UTC로 변환하여 비교합니다.
+
+    시즌패스 계열(google_sku에 "pass" 포함) 영수증은 실제 지급을 IAP가 아닌
+    SeasonPass 서비스가 담당하므로 IAP 통계에서 제외됩니다.
     """
     utc_start = datetime(year, month, 1)
     utc_end = datetime(year + 1, 1, 1) if month == 12 else datetime(year, month + 1, 1)
@@ -1159,6 +1168,10 @@ def get_product_sales(
         Receipt.planet_id.in_(mainnet_planet_ids),
         func.timezone("UTC", Receipt.created_at) >= utc_start,
         func.timezone("UTC", Receipt.created_at) < utc_end,
+        or_(
+            Product.google_sku.is_(None),
+            ~Product.google_sku.ilike(_SEASON_PASS_SKU_ILIKE),
+        ),
     )
 
     # FAV 집계: ticker → FAV__{ticker}


### PR DESCRIPTION
## Summary

- IAP `/stats/product-sales` was including season-pass style purchases (google_sku containing `pass`) in its FAV/Item aggregations, even though those grants are performed by the SeasonPass service — not by IAP.
- The token-distribution report in 9c-backoffice merges this endpoint with SeasonPass's `reward-claims` stats, so season-pass premium grants were **double-counted**.
- Adds a NULL-safe `NOT ILIKE '%pass%'` predicate to the shared `base_filter` so both FAV and Item queries skip season-pass rows.

## Why this SKU rule

Mirrors `purchase.py`'s existing routing check — `if "pass" in product.google_sku` — which is the exact condition that redirects a purchase to the SeasonPass service. Keeping the two in sync means we can't drift.

## Compiled SQL (verified against PostgreSQL dialect)

```sql
WHERE receipt.status = 'VALID'
  AND receipt.planet_id IN ('0x000000000000', '0x000000000001')
  AND timezone('UTC', receipt.created_at) >= '2024-03-01 00:00:00'
  AND timezone('UTC', receipt.created_at) <  '2024-04-01 00:00:00'
  AND (product.google_sku IS NULL
       OR product.google_sku NOT ILIKE '%pass%')
```

## Test plan

- [ ] Deploy to internal environment and hit `/api/admin/stats/product-sales?year=YYYY&month=MM`.
- [ ] Compare FAV/Item totals against a period known to include season-pass premium purchases — expect the premium-attributable amounts to be gone from the IAP side.
- [ ] Cross-check with 9c-backoffice `Token Distribution Stats` page: the IAP column should no longer double up against the SeasonPass column for pass tickers.
- [ ] Historical monthly reports affected by this bug may need re-issuance — tracked separately.

## Notes

- Formal pytest regression test was not added: `Settings()` in `app/config.py` fails to initialize because the local `.env` has fields not declared on the model (`extra_forbidden`), which prevents importing `app.api.admin` in tests. That's out of scope for this ticket. A separate follow-up could add `extra="ignore"` to `SettingsConfigDict` and enable a proper test.
- Verified the fix by compiling the query against the PostgreSQL dialect with literal binds and asserting the WHERE clause contents (see PLD-1357 investigation notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)