### PR TITLE
feat: VoucherGrantOutbox 모델 + 마이그레이션 (PLD-1468)

### DIFF
--- a/apps/shared/shared/enums.py
+++ b/apps/shared/shared/enums.py
@@ -351,3 +351,13 @@ class PlanetID(bytes, Enum):
     HEIMDALL_INTERNAL = b"0x100000000001"
     IDUN_INTERNAL = b"0x100000000002"
     THOR_INTERNAL = b"0x100000000003"
+
+
+class VoucherGrantStatus(IntEnum):
+    """(PLD-1468) NCG Voucher 아웃박스 상태 — 포탈 발급/회수 멱등·재시도 추적."""
+
+    PENDING = 0  # grant 대기/진행
+    GRANTED = 1  # 포탈 grant 성공
+    REVOKE_PENDING = 2  # 환불 감지, revoke 대기
+    REVOKED = 3  # 포탈 revoke 성공
+    FAILED = 4  # 재시도 소진(수동 개입)

--- a/apps/shared/shared/models/__init__.py
+++ b/apps/shared/shared/models/__init__.py
@@ -3,5 +3,6 @@ __all__ = [
     "receipt",
     "product",
     "voucher",
+    "voucher_grant_outbox",
     "user",
 ]

--- a/apps/shared/shared/models/voucher_grant_outbox.py
+++ b/apps/shared/shared/models/voucher_grant_outbox.py
@@ -1,7 +1,8 @@
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, Text
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, Text
 from sqlalchemy.orm import Mapped, backref, relationship
 
-from shared.models.base import AutoIdMixin, Base, TimeStampMixin
+from shared.enums import VoucherGrantStatus
+from shared.models.base import AutoIdMixin, Base, EnumType, TimeStampMixin
 from shared.models.receipt import Receipt
 
 
@@ -28,10 +29,19 @@ class VoucherGrantOutbox(AutoIdMixin, TimeStampMixin, Base):
         backref=backref("voucher_grant_outbox"),
     )
 
-    # PENDING / GRANTED / REVOKE_PENDING / REVOKED / FAILED
-    status = Column(Text, nullable=False, default="PENDING")
+    status = Column(
+        EnumType(VoucherGrantStatus),
+        nullable=False,
+        default=VoucherGrantStatus.PENDING,
+        server_default=str(VoucherGrantStatus.PENDING.value),  # "0" — bulk/upsert/raw insert도 NOT NULL 안전
+    )
     portal_ref = Column(Text, nullable=True, doc="포탈 grant 응답 참조(멱등 확인용)")
-    attempts = Column(Integer, nullable=False, default=0)
+    attempts = Column(Integer, nullable=False, default=0, server_default="0")
     last_error = Column(Text, nullable=True)
     granted_at = Column(DateTime(timezone=True), nullable=True)
     revoked_at = Column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        # 재시도 워커가 미완료(status != GRANTED) 행을 폴링 → status 인덱스.
+        Index("ix_voucher_grant_outbox_status", "status"),
+    )

--- a/apps/shared/shared/models/voucher_grant_outbox.py
+++ b/apps/shared/shared/models/voucher_grant_outbox.py
@@ -1,0 +1,37 @@
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, Text
+from sqlalchemy.orm import Mapped, backref, relationship
+
+from shared.models.base import AutoIdMixin, Base, TimeStampMixin
+from shared.models.receipt import Receipt
+
+
+class VoucherGrantOutbox(AutoIdMixin, TimeStampMixin, Base):
+    """
+    (PLD-1468) NCG Voucher 아웃박스 — 검증된 결제(Receipt)에 대한 포탈 바우처 발급/회수의 멱등·재시도 추적.
+
+    - receipt_id UNIQUE = 1 결제 = 1 행 (멱등).
+    - 지급 트리거(worker)가 포탈 grant 호출 후 status=GRANTED. 실패는 attempts++/last_error 기록 후 재시도.
+    - 리컨사일(beat)이 cutoff 이후 VALID인데 여기 GRANTED가 없는 receipt를 찾아 재호출(포탈 멱등).
+    - 환불 감지 시 REVOKE_PENDING → 포탈 revoke 성공 후 REVOKED.
+
+    권위 있는 바우처 상태(등급/개봉/홀드/회수)는 포탈 `purchase_voucher`에 있고,
+    이 테이블은 IAP측 "포탈에 넘겼나?" 아웃박스 마커일 뿐이다. (고아 `voucher_request` 재사용 대신 신규 — 옛 스키마 의미·스테일 회피)
+    """
+
+    __tablename__ = "voucher_grant_outbox"
+
+    receipt_id = Column(Integer, ForeignKey("receipt.id"), nullable=False, unique=True)
+    receipt: Mapped["Receipt"] = relationship(
+        "Receipt",
+        foreign_keys=[receipt_id],
+        uselist=False,
+        backref=backref("voucher_grant_outbox"),
+    )
+
+    # PENDING / GRANTED / REVOKE_PENDING / REVOKED / FAILED
+    status = Column(Text, nullable=False, default="PENDING")
+    portal_ref = Column(Text, nullable=True, doc="포탈 grant 응답 참조(멱등 확인용)")
+    attempts = Column(Integer, nullable=False, default=0)
+    last_error = Column(Text, nullable=True)
+    granted_at = Column(DateTime(timezone=True), nullable=True)
+    revoked_at = Column(DateTime(timezone=True), nullable=True)

--- a/apps/shared/tool/migrations/versions/8db0d254c89d_add_voucher_grant_outbox.py
+++ b/apps/shared/tool/migrations/versions/8db0d254c89d_add_voucher_grant_outbox.py
@@ -1,0 +1,43 @@
+"""Add voucher_grant_outbox table (PLD-1468)
+
+Revision ID: 8db0d254c89d
+Revises: b1d5e1dc71ea
+Create Date: 2026-08-03 00:00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "8db0d254c89d"
+down_revision = "b1d5e1dc71ea"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # (PLD-1468) NCG Voucher 아웃박스. status는 EnumType(VoucherGrantStatus) = Integer 백엔드.
+    op.create_table(
+        "voucher_grant_outbox",
+        sa.Column("receipt_id", sa.Integer(), nullable=False),
+        sa.Column("status", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("portal_ref", sa.Text(), nullable=True),
+        sa.Column("attempts", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("granted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["receipt_id"], ["receipt.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("receipt_id", name="uq_voucher_grant_outbox_receipt_id"),
+    )
+    op.create_index(
+        "ix_voucher_grant_outbox_status", "voucher_grant_outbox", ["status"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_voucher_grant_outbox_status", table_name="voucher_grant_outbox")
+    op.drop_table("voucher_grant_outbox")


### PR DESCRIPTION
[PLD-1468](https://ninecorporation.atlassian.net/browse/PLD-1468) · 에픽 [PLD-1458](https://ninecorporation.atlassian.net/browse/PLD-1458)

## 변경
- `VoucherGrantOutbox` 모델(`apps/shared/shared/models/voucher_grant_outbox.py`) + `__init__` 등록
- `VoucherGrantStatus(IntEnum)` (enums.py): PENDING/GRANTED/REVOKE_PENDING/REVOKED/FAILED
- Alembic 마이그레이션 `8db0d254c89d` (down_revision=`b1d5e1dc71ea`, 단일 head)

## 역할
검증된 결제(Receipt) → 포탈 바우처 발급/회수의 **IAP측 아웃박스**(`receipt_id` UNIQUE = 멱등). 지급 트리거가 grant 후 GRANTED, 리컨사일이 미완료분 재호출, 환불 시 REVOKE_PENDING→REVOKED. 권위 상태는 포탈 `purchase_voucher`.

## 코드리뷰 반영
- status: raw Text → `EnumType(VoucherGrantStatus)`(오타→중복발급 차단, repo 헬퍼 활용)
- status/attempts `server_default`(bulk/upsert/raw insert NOT NULL 안전)
- status 인덱스(재시도 폴링)
- (정정) Alembic head 1개 확인 → merge 없이 이 마이그로 연결

## 소비 코드(트리거·리컨사일)는 후속 (PLD-1469/1470/1471)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PLD-1468]: https://ninecorporation.atlassian.net/browse/PLD-1468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLD-1458]: https://ninecorporation.atlassian.net/browse/PLD-1458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ