### PR TITLE
feat(voucher): grant 트리거 beat 태스크 (PLD-1469/1472)

### DIFF
--- a/apps/worker/app/celery_app.py
+++ b/apps/worker/app/celery_app.py
@@ -44,6 +44,11 @@ beat_schedule = {
         "schedule": crontab(minute="*/60"),
         "options": {"queue": "background_job_queue"},
     },
+    "voucher-grant-every-2-minutes": {
+        "task": "iap.voucher_grant",
+        "schedule": crontab(minute="*/2"),
+        "options": {"queue": "background_job_queue"},
+    },
 }
 
 app.conf.update(

--- a/apps/worker/app/config.py
+++ b/apps/worker/app/config.py
@@ -26,6 +26,13 @@ class Settings(BaseSettings):
     iap_alert_webhook_url: Optional[str] = None
     iap_sales_webhook_url: Optional[str] = None
 
+    # NCG Voucher 지급 트리거(PLD-1469). 포탈 grant 엔드포인트 + 서버간 JWT(gameBackendApiHandler).
+    portal_grant_url: Optional[str] = None  # 예: https://.../api/voucher/grant
+    portal_revoke_url: Optional[str] = None  # 환불 회수용(PLD-1470)
+    portal_iap_jwt_secret: Optional[str] = None  # 포탈 JWT_IAP_SECRET_KEY와 동일(HS256)
+    voucher_grant_enabled: bool = False  # IAP측 마스터 스위치(포탈 policy.enabled와 별개)
+    voucher_grant_cutoff_receipt_id: int = 0  # 이 id 초과 영수증만 바우처 대상(과거 소급 방지)
+
     google_credential: Optional[str] = None
     google_package_dict: dict[PackageName, str] = {
         PackageName.NINE_CHRONICLES_M: "com.planetariumlabs.ninechroniclesmobile",

--- a/apps/worker/app/tasks/__init__.py
+++ b/apps/worker/app/tasks/__init__.py
@@ -4,3 +4,4 @@ from app.tasks.send_product_task import send_product
 from app.tasks.status_monitor import status_monitor
 from app.tasks.track_google_refund import track_google_refund
 from app.tasks.tracker import track_tx
+from app.tasks.voucher_grant_task import grant_vouchers

--- a/apps/worker/app/tasks/voucher_grant_task.py
+++ b/apps/worker/app/tasks/voucher_grant_task.py
@@ -6,10 +6,15 @@
 
 흐름:
   (A) enroll: cutoff 이후 VALID+SUCCESS+실스토어 영수증 중 아직 아웃박스 없는 건 → PENDING 아웃박스 생성(레이스는 SAVEPOINT로 흡수).
-  (B) dispatch: PENDING 아웃박스 → platform/amountUsd 유도 → 포탈 grant 호출 → GRANTED / 재시도 / FAILED.
+  (B) dispatch: PENDING 아웃박스 → 상태 재검증 → platform/amountUsd 유도 → 포탈 grant 호출 → GRANTED / 재시도(PENDING) / FAILED.
+
+상태 의미:
+  PENDING  = 미처리/재시도 대상(회복 가능한 실패 포함: 인증·레이트리밋·5xx·가격 미활성).
+  GRANTED  = 포탈 grant 성공(종단).
+  FAILED   = 진짜 종단 실패(환불/무효 영수증, 미등록 planet, 금액 상한 초과 등 재시도 무의미) — 알림 대상.
 
 멱등: 아웃박스 receipt_id UNIQUE + 포탈 grant 자체가 iapUuid 멱등. 포탈 policy.enabled=false면 'voucher disabled'로
-      반환되며, 이 경우 아웃박스는 PENDING 유지(활성화 후 재발급).
+      반환되며 PENDING 유지(활성화 후 재발급).
 """
 
 import datetime
@@ -36,13 +41,24 @@ engine = create_engine(
     config.pg_dsn, pool_size=5, max_overflow=10, pool_recycle=3600, pool_pre_ping=True
 )
 
-# 실 결제 스토어 → 바우처 플랫폼. TEST/REDEEM은 바우처 대상 아님(None).
+# 실 결제 스토어 → 바우처 플랫폼. WEB=PC, APPLE/GOOGLE=MOBILE.
+_PROD_STORES = {Store.APPLE, Store.GOOGLE, Store.WEB}
+_TEST_STORES = {Store.APPLE_TEST, Store.GOOGLE_TEST, Store.WEB_TEST}
 _MOBILE_STORES = {Store.APPLE, Store.APPLE_TEST, Store.GOOGLE, Store.GOOGLE_TEST}
 _PC_STORES = {Store.WEB, Store.WEB_TEST}
 
 HTTP_TIMEOUT = 10
 ENROLL_BATCH = 500
 DISPATCH_BATCH = 200
+# 인증(만료/무효 JWT)·레이트리밋·타임아웃은 회복 가능 → transient(재시도). 그 외 4xx는 종단.
+_TRANSIENT_STATUS = {401, 403, 408, 429}
+
+
+def _grantable_stores() -> set:
+    """바우처 대상 스토어. production에선 실 스토어만, 그 외(dev/staging)엔 샌드박스도 포함(e2e)."""
+    if config.stage == "production":
+        return set(_PROD_STORES)
+    return _PROD_STORES | _TEST_STORES
 
 
 def platform_for_store(store: Store) -> Optional[str]:
@@ -55,13 +71,17 @@ def platform_for_store(store: Store) -> Optional[str]:
 
 
 def usd_amount_for_product(sess, product_id: int) -> Optional[Decimal]:
-    """(PLD-1472) 상품 USD 가격(WEB 스토어=canonical USD). 없거나 <=0이면 None."""
+    """(PLD-1472) 상품 USD 가격(WEB 스토어=canonical USD). active만, 다중행이면 최신 1건. 없으면 None."""
     price = sess.scalar(
-        select(Price).where(
+        select(Price)
+        .where(
             Price.product_id == product_id,
             Price.currency == "USD",
             Price.store == Store.WEB,
+            Price.active.is_(True),
         )
+        .order_by(Price.id.desc())
+        .limit(1)
     )
     if price is None or price.price is None or Decimal(str(price.price)) <= 0:
         return None
@@ -77,10 +97,11 @@ def _planet_str(planet_id) -> str:
 
 def _make_jwt() -> str:
     """포탈 gameBackendApiHandler용 서버간 JWT(HS256, 1분 만료)."""
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     return jwt.encode(
         {"iat": now, "exp": now + datetime.timedelta(minutes=1), "iss": "iap"},
         config.portal_iap_jwt_secret,
+        algorithm="HS256",
     )
 
 
@@ -88,8 +109,8 @@ def _post_grant(payload: dict) -> Tuple[bool, Optional[str], bool]:
     """
     포탈 grant 호출. 반환 (terminal_ok, ref, transient):
       - terminal_ok=True  → GRANTED로 종료(success/already granted/amount too small)
-      - transient=True     → 재시도(PENDING 유지): 5xx 또는 'voucher disabled'(아직 미활성)
-      - 둘 다 False         → FAILED(4xx 검증오류 등, 재시도해도 동일)
+      - transient=True     → 재시도(PENDING 유지): 5xx·인증(401/403)·레이트리밋(429)·타임아웃(408) 또는 'voucher disabled'
+      - 둘 다 False         → FAILED(그 외 4xx = 검증오류, 재시도해도 동일)
     """
     resp = requests.post(
         config.portal_grant_url,
@@ -97,15 +118,27 @@ def _post_grant(payload: dict) -> Tuple[bool, Optional[str], bool]:
         headers={"Authorization": f"Bearer {_make_jwt()}"},
         timeout=HTTP_TIMEOUT,
     )
-    if resp.status_code >= 500:
+    if resp.status_code >= 500 or resp.status_code in _TRANSIENT_STATUS:
         return False, f"{resp.status_code}", True
     if resp.status_code != 200:
         return False, f"{resp.status_code}:{resp.text[:200]}", False
     body = resp.json()
-    msg = body.get("message", "")
-    if msg == "voucher disabled":
+    if not isinstance(body, dict):
+        return False, f"unexpected body: {str(body)[:100]}", False
+    if body.get("message") == "voucher disabled":
         return False, None, True  # 킬스위치 off — 활성화 후 재발급
     return True, f"granted={body.get('granted')}", False
+
+
+def _alert(text: str) -> None:
+    """운영 알림(best-effort). 실패해도 태스크 진행을 막지 않음."""
+    url = config.iap_alert_webhook_url
+    if not url:
+        return
+    try:
+        requests.post(url, json={"text": text}, timeout=HTTP_TIMEOUT)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("voucher grant alert failed", error=str(e))
 
 
 @app.task(
@@ -122,10 +155,13 @@ def grant_vouchers(self):
         logger.warning("voucher grant not configured (url/secret missing)")
         return "not configured"
 
+    grantable = _grantable_stores()
     sess = scoped_session(sessionmaker(bind=engine))
     enrolled = granted = failed = 0
     try:
-        # (A) enroll — 적격 영수증 중 아웃박스 없는 건을 PENDING으로.
+        # (A) enroll — 적격 영수증(실스토어) 중 아웃박스 없는 건을 PENDING으로.
+        #   ⚠️ 스토어 필터를 SQL에 둠: skip 대상(REDEEM 등)을 Python에서 거르면 아웃박스가 안 생겨
+        #      매 회차 재조회되어 limit 윈도우를 침전·starve시킨다(리뷰 지적).
         eligible = (
             sess.execute(
                 select(Receipt)
@@ -134,6 +170,7 @@ def grant_vouchers(self):
                     Receipt.status == ReceiptStatus.VALID,
                     Receipt.tx_status == TxStatus.SUCCESS,
                     Receipt.product_id.isnot(None),
+                    Receipt.store.in_(grantable),
                     Receipt.id.notin_(select(VoucherGrantOutbox.receipt_id)),
                 )
                 .order_by(Receipt.id)
@@ -143,8 +180,6 @@ def grant_vouchers(self):
             .all()
         )
         for r in eligible:
-            if platform_for_store(Store(r.store)) is None:
-                continue  # TEST/REDEEM 등 — 아웃박스도 만들지 않음(다음 회차에도 스킵)
             try:
                 with sess.begin_nested():  # SAVEPOINT — 레이스 시 이 행만 롤백
                     sess.add(VoucherGrantOutbox(receipt_id=r.id))
@@ -153,67 +188,98 @@ def grant_vouchers(self):
                 pass  # 이미 등록됨(동시 실행) — 무시
         sess.commit()
 
-        # (B) dispatch — PENDING 아웃박스를 포탈 grant로.
+        # (B) dispatch — PENDING 아웃박스를 포탈 grant로. 행 잠금(skip_locked)으로 동시 실행 중복 방지.
         pendings = (
             sess.execute(
                 select(VoucherGrantOutbox)
                 .where(VoucherGrantOutbox.status == VoucherGrantStatus.PENDING)
                 .order_by(VoucherGrantOutbox.receipt_id)
                 .limit(DISPATCH_BATCH)
+                .with_for_update(skip_locked=True)
             )
             .scalars()
             .all()
         )
         for ob in pendings:
-            r = sess.scalar(select(Receipt).where(Receipt.id == ob.receipt_id))
-            if r is None:
-                ob.status = VoucherGrantStatus.FAILED
-                ob.last_error = "receipt not found"
-                failed += 1
-                continue
-            platform = platform_for_store(Store(r.store))
-            amount_usd = (
-                usd_amount_for_product(sess, r.product_id) if r.product_id else None
-            )
-            if platform is None or amount_usd is None:
-                ob.status = VoucherGrantStatus.FAILED
-                ob.last_error = f"platform={platform} amount_usd={amount_usd}"
-                failed += 1
-                continue
-
-            payload = {
-                "iapUuid": str(r.uuid),
-                "receiptId": r.id,
-                "agentAddress": r.agent_addr,
-                "planetId": _planet_str(r.planet_id),
-                "amountUsd": float(amount_usd),
-                "platform": platform,
-                "purchasedAt": (r.purchased_at or r.created_at).isoformat(),
-            }
+            # 행별 격리 — 한 건의 예상외 예외가 배치 전체를 롤백/중단시키지 않게.
             try:
-                ok, ref, transient = _post_grant(payload)
-            except requests.RequestException as e:
-                ob.attempts = (ob.attempts or 0) + 1
-                ob.last_error = f"http error: {e}"[:500]
-                continue  # transient — PENDING 유지
+                r = sess.scalar(select(Receipt).where(Receipt.id == ob.receipt_id))
+                if r is None:
+                    ob.status = VoucherGrantStatus.FAILED
+                    ob.last_error = "receipt not found"
+                    failed += 1
+                    continue
 
-            if ok:
-                ob.status = VoucherGrantStatus.GRANTED
-                ob.portal_ref = ref
-                ob.granted_at = datetime.datetime.now(datetime.timezone.utc)
-                granted += 1
-            elif transient:
+                # dispatch 시점 상태 재검증 — enroll 이후 환불/무효 전이 시 발급 금지(종단).
+                if r.status != ReceiptStatus.VALID or r.tx_status != TxStatus.SUCCESS:
+                    ob.status = VoucherGrantStatus.FAILED
+                    ob.last_error = (
+                        f"receipt no longer grantable: status={r.status} tx={r.tx_status}"
+                    )
+                    failed += 1
+                    continue
+
+                platform = platform_for_store(Store(r.store))
+                if platform is None:
+                    # 실스토어 아님(설정/데이터 이상) — enroll 필터상 도달 어려우나 방어적 종단.
+                    ob.status = VoucherGrantStatus.FAILED
+                    ob.last_error = f"non-grantable store: {r.store}"
+                    failed += 1
+                    continue
+
+                amount_usd = (
+                    usd_amount_for_product(sess, r.product_id) if r.product_id else None
+                )
+                if amount_usd is None:
+                    # 가격이 아직 미활성일 수 있음 → 종단 아닌 재시도(PENDING 유지).
+                    ob.attempts = (ob.attempts or 0) + 1
+                    ob.last_error = "usd price not found/active (retry)"
+                    continue
+
+                payload = {
+                    "iapUuid": str(r.uuid),
+                    "receiptId": r.id,
+                    "agentAddress": r.agent_addr,
+                    "planetId": _planet_str(r.planet_id),
+                    "amountUsd": float(amount_usd),
+                    "platform": platform,
+                    "purchasedAt": (r.purchased_at or r.created_at).isoformat(),
+                }
+                try:
+                    ok, ref, transient = _post_grant(payload)
+                except requests.RequestException as e:
+                    ob.attempts = (ob.attempts or 0) + 1
+                    ob.last_error = f"http error: {e}"[:500]
+                    continue  # transient — PENDING 유지
+
+                if ok:
+                    ob.status = VoucherGrantStatus.GRANTED
+                    ob.portal_ref = ref
+                    ob.granted_at = datetime.datetime.now(datetime.timezone.utc)
+                    granted += 1
+                elif transient:
+                    ob.attempts = (ob.attempts or 0) + 1
+                    ob.last_error = (
+                        f"transient (retry): {ref}" if ref else "transient (retry)"
+                    )
+                else:
+                    ob.status = VoucherGrantStatus.FAILED
+                    ob.attempts = (ob.attempts or 0) + 1
+                    ob.last_error = ref or "grant failed"
+                    failed += 1
+            except Exception as e:  # noqa: BLE001
+                # 예상외 예외(비정상 데이터 등) — 이 행만 재시도로 남기고 배치는 계속.
                 ob.attempts = (ob.attempts or 0) + 1
-                ob.last_error = "transient (retry)"
-            else:
-                ob.status = VoucherGrantStatus.FAILED
-                ob.attempts = (ob.attempts or 0) + 1
-                ob.last_error = ref or "grant failed"
-                failed += 1
+                ob.last_error = f"unexpected: {e}"[:500]
         sess.commit()
 
         result = f"enrolled={enrolled} granted={granted} failed={failed}"
         logger.info("voucher grant run", result=result)
+        if failed > 0:
+            # FAILED는 종단(무재시도)이라 미지급이 침묵으로 굳지 않도록 알림.
+            _alert(
+                f"[voucher-grant] {failed} receipt(s) marked FAILED (manual review). {result}"
+            )
         return result
     except Exception:
         sess.rollback()

--- a/apps/worker/app/tasks/voucher_grant_task.py
+++ b/apps/worker/app/tasks/voucher_grant_task.py
@@ -1,0 +1,222 @@
+"""
+(PLD-1469/1472) NCG Voucher 지급 트리거.
+
+검증 완료(VALID) + 상품 지급 성공(tx SUCCESS)한 결제를 폴링해 포탈 grant를 호출하는 beat 태스크.
+복잡한 send_product handle()을 건드리지 않고 아웃박스(voucher_grant_outbox)로 디커플링 — 멱등·재시도.
+
+흐름:
+  (A) enroll: cutoff 이후 VALID+SUCCESS+실스토어 영수증 중 아직 아웃박스 없는 건 → PENDING 아웃박스 생성(레이스는 SAVEPOINT로 흡수).
+  (B) dispatch: PENDING 아웃박스 → platform/amountUsd 유도 → 포탈 grant 호출 → GRANTED / 재시도 / FAILED.
+
+멱등: 아웃박스 receipt_id UNIQUE + 포탈 grant 자체가 iapUuid 멱등. 포탈 policy.enabled=false면 'voucher disabled'로
+      반환되며, 이 경우 아웃박스는 PENDING 유지(활성화 후 재발급).
+"""
+
+import datetime
+from decimal import Decimal
+from typing import Optional, Tuple
+
+import jwt
+import requests
+import structlog
+from shared.enums import ReceiptStatus, Store, TxStatus, VoucherGrantStatus
+from shared.models.product import Price
+from shared.models.receipt import Receipt
+from shared.models.voucher_grant_outbox import VoucherGrantOutbox
+from sqlalchemy import create_engine, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from app.celery_app import app
+from app.config import config
+
+logger = structlog.get_logger(__name__)
+
+engine = create_engine(
+    config.pg_dsn, pool_size=5, max_overflow=10, pool_recycle=3600, pool_pre_ping=True
+)
+
+# 실 결제 스토어 → 바우처 플랫폼. TEST/REDEEM은 바우처 대상 아님(None).
+_MOBILE_STORES = {Store.APPLE, Store.APPLE_TEST, Store.GOOGLE, Store.GOOGLE_TEST}
+_PC_STORES = {Store.WEB, Store.WEB_TEST}
+
+HTTP_TIMEOUT = 10
+ENROLL_BATCH = 500
+DISPATCH_BATCH = 200
+
+
+def platform_for_store(store: Store) -> Optional[str]:
+    """(PLD-1472) 스토어 → 플랫폼. WEB=PC, APPLE/GOOGLE=MOBILE. TEST/REDEEM=None(대상 아님)."""
+    if store in _PC_STORES:
+        return "PC"
+    if store in _MOBILE_STORES:
+        return "MOBILE"
+    return None
+
+
+def usd_amount_for_product(sess, product_id: int) -> Optional[Decimal]:
+    """(PLD-1472) 상품 USD 가격(WEB 스토어=canonical USD). 없거나 <=0이면 None."""
+    price = sess.scalar(
+        select(Price).where(
+            Price.product_id == product_id,
+            Price.currency == "USD",
+            Price.store == Store.WEB,
+        )
+    )
+    if price is None or price.price is None or Decimal(str(price.price)) <= 0:
+        return None
+    return Decimal(str(price.price))
+
+
+def _planet_str(planet_id) -> str:
+    """planet_id(LargeBinary) → hex 문자열('0x...')."""
+    if isinstance(planet_id, (bytes, bytearray, memoryview)):
+        return bytes(planet_id).decode()
+    return str(planet_id)
+
+
+def _make_jwt() -> str:
+    """포탈 gameBackendApiHandler용 서버간 JWT(HS256, 1분 만료)."""
+    now = datetime.datetime.utcnow()
+    return jwt.encode(
+        {"iat": now, "exp": now + datetime.timedelta(minutes=1), "iss": "iap"},
+        config.portal_iap_jwt_secret,
+    )
+
+
+def _post_grant(payload: dict) -> Tuple[bool, Optional[str], bool]:
+    """
+    포탈 grant 호출. 반환 (terminal_ok, ref, transient):
+      - terminal_ok=True  → GRANTED로 종료(success/already granted/amount too small)
+      - transient=True     → 재시도(PENDING 유지): 5xx 또는 'voucher disabled'(아직 미활성)
+      - 둘 다 False         → FAILED(4xx 검증오류 등, 재시도해도 동일)
+    """
+    resp = requests.post(
+        config.portal_grant_url,
+        json=payload,
+        headers={"Authorization": f"Bearer {_make_jwt()}"},
+        timeout=HTTP_TIMEOUT,
+    )
+    if resp.status_code >= 500:
+        return False, f"{resp.status_code}", True
+    if resp.status_code != 200:
+        return False, f"{resp.status_code}:{resp.text[:200]}", False
+    body = resp.json()
+    msg = body.get("message", "")
+    if msg == "voucher disabled":
+        return False, None, True  # 킬스위치 off — 활성화 후 재발급
+    return True, f"granted={body.get('granted')}", False
+
+
+@app.task(
+    name="iap.voucher_grant",
+    bind=True,
+    acks_late=True,
+    queue="background_job_queue",
+)
+def grant_vouchers(self):
+    """검증된 결제에 대한 포탈 바우처 발급 트리거(beat, */2분)."""
+    if not config.voucher_grant_enabled:
+        return "voucher grant disabled"
+    if not (config.portal_grant_url and config.portal_iap_jwt_secret):
+        logger.warning("voucher grant not configured (url/secret missing)")
+        return "not configured"
+
+    sess = scoped_session(sessionmaker(bind=engine))
+    enrolled = granted = failed = 0
+    try:
+        # (A) enroll — 적격 영수증 중 아웃박스 없는 건을 PENDING으로.
+        eligible = (
+            sess.execute(
+                select(Receipt)
+                .where(
+                    Receipt.id > config.voucher_grant_cutoff_receipt_id,
+                    Receipt.status == ReceiptStatus.VALID,
+                    Receipt.tx_status == TxStatus.SUCCESS,
+                    Receipt.product_id.isnot(None),
+                    Receipt.id.notin_(select(VoucherGrantOutbox.receipt_id)),
+                )
+                .order_by(Receipt.id)
+                .limit(ENROLL_BATCH)
+            )
+            .scalars()
+            .all()
+        )
+        for r in eligible:
+            if platform_for_store(Store(r.store)) is None:
+                continue  # TEST/REDEEM 등 — 아웃박스도 만들지 않음(다음 회차에도 스킵)
+            try:
+                with sess.begin_nested():  # SAVEPOINT — 레이스 시 이 행만 롤백
+                    sess.add(VoucherGrantOutbox(receipt_id=r.id))
+                enrolled += 1
+            except IntegrityError:
+                pass  # 이미 등록됨(동시 실행) — 무시
+        sess.commit()
+
+        # (B) dispatch — PENDING 아웃박스를 포탈 grant로.
+        pendings = (
+            sess.execute(
+                select(VoucherGrantOutbox)
+                .where(VoucherGrantOutbox.status == VoucherGrantStatus.PENDING)
+                .order_by(VoucherGrantOutbox.receipt_id)
+                .limit(DISPATCH_BATCH)
+            )
+            .scalars()
+            .all()
+        )
+        for ob in pendings:
+            r = sess.scalar(select(Receipt).where(Receipt.id == ob.receipt_id))
+            if r is None:
+                ob.status = VoucherGrantStatus.FAILED
+                ob.last_error = "receipt not found"
+                failed += 1
+                continue
+            platform = platform_for_store(Store(r.store))
+            amount_usd = (
+                usd_amount_for_product(sess, r.product_id) if r.product_id else None
+            )
+            if platform is None or amount_usd is None:
+                ob.status = VoucherGrantStatus.FAILED
+                ob.last_error = f"platform={platform} amount_usd={amount_usd}"
+                failed += 1
+                continue
+
+            payload = {
+                "iapUuid": str(r.uuid),
+                "receiptId": r.id,
+                "agentAddress": r.agent_addr,
+                "planetId": _planet_str(r.planet_id),
+                "amountUsd": float(amount_usd),
+                "platform": platform,
+                "purchasedAt": (r.purchased_at or r.created_at).isoformat(),
+            }
+            try:
+                ok, ref, transient = _post_grant(payload)
+            except requests.RequestException as e:
+                ob.attempts = (ob.attempts or 0) + 1
+                ob.last_error = f"http error: {e}"[:500]
+                continue  # transient — PENDING 유지
+
+            if ok:
+                ob.status = VoucherGrantStatus.GRANTED
+                ob.portal_ref = ref
+                ob.granted_at = datetime.datetime.now(datetime.timezone.utc)
+                granted += 1
+            elif transient:
+                ob.attempts = (ob.attempts or 0) + 1
+                ob.last_error = "transient (retry)"
+            else:
+                ob.status = VoucherGrantStatus.FAILED
+                ob.attempts = (ob.attempts or 0) + 1
+                ob.last_error = ref or "grant failed"
+                failed += 1
+        sess.commit()
+
+        result = f"enrolled={enrolled} granted={granted} failed={failed}"
+        logger.info("voucher grant run", result=result)
+        return result
+    except Exception:
+        sess.rollback()
+        raise
+    finally:
+        sess.remove()

--- a/apps/worker/tests/test_voucher_grant_task.py
+++ b/apps/worker/tests/test_voucher_grant_task.py
@@ -1,0 +1,125 @@
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.tasks import voucher_grant_task as vg
+from shared.enums import Store
+
+
+class TestPlatformForStore:
+    @pytest.mark.parametrize(
+        "store,expected",
+        [
+            (Store.WEB, "PC"),
+            (Store.WEB_TEST, "PC"),
+            (Store.APPLE, "MOBILE"),
+            (Store.APPLE_TEST, "MOBILE"),
+            (Store.GOOGLE, "MOBILE"),
+            (Store.GOOGLE_TEST, "MOBILE"),
+            (Store.TEST, None),  # 디버그 — 바우처 대상 아님
+            (Store.REDEEM, None),  # 코드 리딤 — 결제 아님
+        ],
+    )
+    def test_mapping(self, store, expected):
+        assert vg.platform_for_store(store) == expected
+
+
+class TestPlanetStr:
+    def test_bytes(self):
+        assert vg._planet_str(b"0x000000000000") == "0x000000000000"
+
+    def test_memoryview(self):
+        assert vg._planet_str(memoryview(b"0x000000000001")) == "0x000000000001"
+
+    def test_str_passthrough(self):
+        assert vg._planet_str("0x000000000000") == "0x000000000000"
+
+
+class TestUsdAmountForProduct:
+    def _sess_with(self, price_val):
+        sess = MagicMock()
+        if price_val is None:
+            sess.scalar.return_value = None
+        else:
+            price = MagicMock()
+            price.price = price_val
+            sess.scalar.return_value = price
+        return sess
+
+    def test_returns_usd_decimal(self):
+        assert vg.usd_amount_for_product(self._sess_with(Decimal("4.99")), 1) == Decimal(
+            "4.99"
+        )
+
+    def test_none_when_no_price(self):
+        assert vg.usd_amount_for_product(self._sess_with(None), 1) is None
+
+    def test_none_when_zero_or_negative(self):
+        assert vg.usd_amount_for_product(self._sess_with(Decimal("0")), 1) is None
+        assert vg.usd_amount_for_product(self._sess_with(Decimal("-1")), 1) is None
+
+
+class TestPostGrant:
+    """포탈 grant 응답 분류: (terminal_ok, ref, transient)."""
+
+    def _resp(self, status, body=None):
+        r = MagicMock()
+        r.status_code = status
+        r.text = "err-body"
+        r.json = MagicMock(return_value=body if body is not None else {})
+        return r
+
+    def _run(self, resp):
+        with patch.object(vg.config, "portal_grant_url", "http://portal/api/voucher/grant"), \
+            patch.object(vg.config, "portal_iap_jwt_secret", "secret"), \
+            patch.object(vg.requests, "post", return_value=resp) as post:
+            return vg._post_grant({"iapUuid": "x"}), post
+
+    def test_success_is_terminal(self):
+        (ok, ref, transient), post = self._run(
+            self._resp(200, {"message": "success", "granted": 2})
+        )
+        assert ok is True and transient is False and "granted=2" in ref
+        # Authorization: Bearer <jwt> 헤더 부착 확인
+        assert post.call_args.kwargs["headers"]["Authorization"].startswith("Bearer ")
+
+    def test_already_granted_is_terminal(self):
+        (ok, ref, transient), _ = self._run(
+            self._resp(200, {"message": "already granted", "granted": 3})
+        )
+        assert ok is True and transient is False
+
+    def test_amount_too_small_is_terminal(self):
+        (ok, ref, transient), _ = self._run(
+            self._resp(200, {"message": "no voucher (amount too small)", "granted": 0})
+        )
+        assert ok is True and transient is False
+
+    def test_voucher_disabled_is_transient(self):
+        # 킬스위치 off — 활성화 후 재발급해야 하므로 재시도(PENDING 유지).
+        (ok, ref, transient), _ = self._run(
+            self._resp(200, {"message": "voucher disabled", "granted": 0})
+        )
+        assert ok is False and transient is True
+
+    def test_5xx_is_transient(self):
+        (ok, ref, transient), _ = self._run(self._resp(500))
+        assert ok is False and transient is True
+
+    def test_4xx_is_terminal_failure(self):
+        # 검증오류 — 재시도해도 동일 → FAILED.
+        (ok, ref, transient), _ = self._run(self._resp(400, {}))
+        assert ok is False and transient is False and ref.startswith("400")
+
+
+class TestGrantVouchersGating:
+    def test_disabled_returns_early(self):
+        with patch.object(vg.config, "voucher_grant_enabled", False):
+            assert vg.grant_vouchers.run() == "voucher grant disabled"
+
+    def test_not_configured_returns_early(self):
+        with patch.object(vg.config, "voucher_grant_enabled", True), \
+            patch.object(vg.config, "portal_grant_url", None), \
+            patch.object(vg.config, "portal_iap_jwt_secret", None):
+            assert vg.grant_vouchers.run() == "not configured"

--- a/apps/worker/tests/test_voucher_grant_task.py
+++ b/apps/worker/tests/test_voucher_grant_task.py
@@ -107,10 +107,33 @@ class TestPostGrant:
         (ok, ref, transient), _ = self._run(self._resp(500))
         assert ok is False and transient is True
 
+    def test_auth_and_ratelimit_are_transient(self):
+        # 인증(401/403)·레이트리밋(429)·타임아웃(408)은 회복 가능 → 재시도(종단 아님).
+        for status in (401, 403, 408, 429):
+            (ok, ref, transient), _ = self._run(self._resp(status))
+            assert ok is False and transient is True, f"status {status} should be transient"
+
     def test_4xx_is_terminal_failure(self):
-        # 검증오류 — 재시도해도 동일 → FAILED.
+        # 검증오류(400 등) — 재시도해도 동일 → FAILED.
         (ok, ref, transient), _ = self._run(self._resp(400, {}))
         assert ok is False and transient is False and ref.startswith("400")
+
+    def test_non_object_body_is_terminal(self):
+        (ok, ref, transient), _ = self._run(self._resp(200, [1, 2, 3]))
+        assert ok is False and transient is False
+
+
+class TestGrantableStores:
+    def test_production_excludes_sandbox(self):
+        with patch.object(vg.config, "stage", "production"):
+            s = vg._grantable_stores()
+        assert Store.APPLE in s and Store.GOOGLE in s and Store.WEB in s
+        assert Store.APPLE_TEST not in s and Store.WEB_TEST not in s
+
+    def test_nonprod_includes_sandbox(self):
+        with patch.object(vg.config, "stage", "development"):
+            s = vg._grantable_stores()
+        assert Store.APPLE_TEST in s and Store.WEB_TEST in s and Store.GOOGLE_TEST in s
 
 
 class TestGrantVouchersGating:


### PR DESCRIPTION
## 요약
검증완료(VALID)+상품지급성공(tx SUCCESS) 결제를 폴링해 포탈 `/api/voucher/grant`를 호출하는 beat 태스크(`*/2분`). 아웃박스(#PLD-1468) 위에 스택.

복잡한 `send_product.handle()`을 건드리지 않고 아웃박스(`voucher_grant_outbox`)로 디커플링 — 멱등·재시도.

## 흐름
- **enroll**: cutoff 이후 적격(VALID+SUCCESS+실스토어) 영수증 중 아웃박스 없는 건 → PENDING 생성. 레이스는 SAVEPOINT(`begin_nested`)로 흡수
- **dispatch**: PENDING → platform/amountUsd 유도 → 포탈 grant → GRANTED / 재시도(PENDING) / FAILED
- **platform**(PLD-1472): WEB=PC, APPLE/GOOGLE=MOBILE, TEST/REDEEM=대상 아님
- **amountUsd**(PLD-1472): 상품 WEB/USD 가격(canonical USD)
- **응답 분류**: `success`/`already granted`/`amount too small`=종료, `voucher disabled`(미활성)·5xx=재시도, 4xx=FAILED

## 안전장치
- 멱등: 아웃박스 `receipt_id` UNIQUE + 포탈 grant 자체 `iapUuid` 멱등(이중지급 방지)
- `voucher_grant_cutoff_receipt_id`로 과거 결제 소급 방지
- `voucher_grant_enabled` 마스터 스위치(포탈 policy.enabled와 별개) + url/secret 미설정 시 no-op
- 서버간 JWT(HS256, 1분 만료) → 포탈 gameBackendApiHandler

## 테스트 22건
platform/planet/amount 유도, `_post_grant` 응답 분류(종료/재시도/실패), config 게이팅.