### PR TITLE
chore(security): gitignore env_config.json (PLD-1477)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,5 @@ cdk.out/
 # env
 .env*
 .direnv
+# 로컬 시크릿 번들(Stripe sk_live / DB 비번 / KMS·서명키 등). 절대 커밋 금지.
+env_config.json


### PR DESCRIPTION
## 요약
`env_config.json`(Stripe `sk_live`·DB 비번·KMS/서명키 등 **프로덕션 시크릿 번들**)이 미추적이나 `.gitignore`에 없어서 실수로 `git add` 시 커밋될 위험이 있었음.

`.env*` 패턴은 `env_config.json`(앞에 점 없음)을 매치하지 못함 → 명시적으로 추가.

## ⚠️ 별개 조치 필요(사람)
이미 로컬/공유 경로에 평문으로 존재해온 시크릿이므로 **로테이션 권고**(Stripe/DB/KMS·서명키). 이 PR은 재발 방지(추적 차단)만.