### PR TITLE
feat(voucher): 회수/리컨사일 — 환불 방어 (PLD-1470/1471)

### DIFF
--- a/apps/worker/app/celery_app.py
+++ b/apps/worker/app/celery_app.py
@@ -49,6 +49,11 @@ beat_schedule = {
         "schedule": crontab(minute="*/2"),
         "options": {"queue": "background_job_queue"},
     },
+    "voucher-reconcile-every-5-minutes": {
+        "task": "iap.voucher_reconcile",
+        "schedule": crontab(minute="*/5"),
+        "options": {"queue": "background_job_queue"},
+    },
 }
 
 app.conf.update(

--- a/apps/worker/app/tasks/__init__.py
+++ b/apps/worker/app/tasks/__init__.py
@@ -5,3 +5,4 @@ from app.tasks.status_monitor import status_monitor
 from app.tasks.track_google_refund import track_google_refund
 from app.tasks.tracker import track_tx
 from app.tasks.voucher_grant_task import grant_vouchers
+from app.tasks.voucher_reconcile_task import reconcile_vouchers

--- a/apps/worker/app/tasks/track_google_refund.py
+++ b/apps/worker/app/tasks/track_google_refund.py
@@ -9,6 +9,7 @@ from shared.utils.google import get_google_client
 
 from app.celery_app import app
 from app.config import config
+from app.tasks.voucher_reconcile_task import enqueue_revoke_by_order_ids
 
 logger = structlog.get_logger(__name__)
 
@@ -74,6 +75,8 @@ def handle(event, context):
     current_time = datetime.now(timezone.utc)
     one_hour_ago = current_time - timedelta(hours=1)
 
+    refunded_order_ids: list[str] = []  # (PLD-1470) 바우처 회수 큐잉용
+
     start_time_ms = int(one_hour_ago.timestamp() * 1000)
     end_time_ms = int(current_time.timestamp() * 1000)
 
@@ -121,10 +124,20 @@ def handle(event, context):
             logger.info(
                 f"환불 알림 전송: {void.orderId} (환불 시간: {void.voidedTime.isoformat()})"
             )
+            refunded_order_ids.append(void.orderId)
 
         logger.info(
             f"{package_name.value} 패키지에서 {len(voided_purchases)}개의 최근 환불 데이터를 처리했습니다."
         )
+
+    # (PLD-1470) 환불된 결제의 NCG 바우처 회수 큐잉(아웃박스 REVOKE_PENDING). 알림 흐름과 독립·best-effort.
+    #   google buyer 환불은 receipt.status를 갱신하지 않으므로 이 훅이 유일 신호원.
+    try:
+        queued = enqueue_revoke_by_order_ids(refunded_order_ids)
+        if queued:
+            logger.info(f"바우처 회수 큐잉 {queued}건")
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"바우처 회수 큐잉 실패(알림은 정상): {e}")
 
 
 @app.task(

--- a/apps/worker/app/tasks/voucher_reconcile_task.py
+++ b/apps/worker/app/tasks/voucher_reconcile_task.py
@@ -1,0 +1,250 @@
+"""
+(PLD-1470/1471) NCG Voucher 회수/리컨사일.
+
+환불 감지 → 포탈 revoke 호출을 아웃박스(voucher_grant_outbox)를 단일 조율점으로 처리.
+
+두 갈래로 REVOKE_PENDING이 큐잉된다:
+  - google buyer 환불: track_google_refund가 void 감지 시 `enqueue_revoke_by_order_id`로 큐잉
+    (google 환불은 receipt.status를 갱신하지 않으므로 훅이 유일 신호원).
+  - admin 환불/무효(status=REFUNDED_*/INVALID): 이 태스크의 status 기반 enroll이 잡음.
+
+아웃박스가 단일 조율점인 이유:
+  - REVOKE_PENDING/REVOKED 행은 grant enroll의 notin_에 걸려 재등록 안 되고, grant dispatch(PENDING만)도 안 탄다
+    → 환불이 grant보다 먼저 도착해도(REVOKE_PENDING로 생성) 발급이 선점적으로 차단된다.
+  - revoke dispatch가 REVOKE_PENDING → 포탈 revoke → REVOKED.
+
+멱등: 포탈 revoke 자체가 iapUuid 기준 멱등(미개봉만 회수, 개봉건은 skippedOpened+경보). 재시도 안전.
+"""
+
+import datetime
+from typing import Optional, Tuple
+
+import jwt
+import requests
+import structlog
+from shared.enums import ReceiptStatus, VoucherGrantStatus
+from shared.models.receipt import Receipt
+from shared.models.voucher_grant_outbox import VoucherGrantOutbox
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from app.celery_app import app
+from app.config import config
+
+logger = structlog.get_logger(__name__)
+
+engine = create_engine(
+    config.pg_dsn, pool_size=5, max_overflow=10, pool_recycle=3600, pool_pre_ping=True
+)
+
+HTTP_TIMEOUT = 10
+REVOKE_BATCH = 200
+ENROLL_BATCH = 500
+_TRANSIENT_STATUS = {401, 403, 408, 429}
+# 환불/무효 — 발급된 바우처를 회수해야 하는 receipt 상태.
+_REFUNDED_STATUSES = [
+    ReceiptStatus.REFUNDED_BY_ADMIN,
+    ReceiptStatus.REFUNDED_BY_BUYER,
+    ReceiptStatus.INVALID,
+]
+
+
+def _make_jwt() -> str:
+    """포탈 gameBackendApiHandler용 서버간 JWT(HS256, 1분 만료)."""
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return jwt.encode(
+        {"iat": now, "exp": now + datetime.timedelta(minutes=1), "iss": "iap"},
+        config.portal_iap_jwt_secret,
+        algorithm="HS256",
+    )
+
+
+def _post_revoke(iap_uuid: str) -> Tuple[bool, Optional[str], bool]:
+    """
+    포탈 revoke 호출. 반환 (ok, ref, transient):
+      - ok=True     → REVOKED로 종료
+      - transient   → 재시도(REVOKE_PENDING 유지): 5xx·인증·레이트리밋·타임아웃
+      - 둘 다 False  → 재시도 무의미한 오류(4xx). revoke는 유실이 곧 미회수(환불 NCG 잔존)이므로
+                        드롭하지 않고 REVOKE_PENDING 유지 + 경보로 사람 개입 유도(상위에서 처리).
+    """
+    resp = requests.post(
+        config.portal_revoke_url,
+        json={"iapUuid": iap_uuid},
+        headers={"Authorization": f"Bearer {_make_jwt()}"},
+        timeout=HTTP_TIMEOUT,
+    )
+    if resp.status_code >= 500 or resp.status_code in _TRANSIENT_STATUS:
+        return False, f"{resp.status_code}", True
+    if resp.status_code != 200:
+        return False, f"{resp.status_code}:{resp.text[:200]}", False
+    body = resp.json()
+    if not isinstance(body, dict):
+        return False, f"unexpected body: {str(body)[:100]}", False
+    skipped = body.get("skippedOpened") or []
+    ref = (
+        f"revoked={body.get('revoked')} already={body.get('alreadyRevoked')} "
+        f"skippedOpened={skipped}"
+    )
+    return True, ref, False
+
+
+def _alert(text: str) -> None:
+    url = config.iap_alert_webhook_url
+    if not url:
+        return
+    try:
+        requests.post(url, json={"text": text}, timeout=HTTP_TIMEOUT)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("voucher reconcile alert failed", error=str(e))
+
+
+def enqueue_revoke_for_receipt(sess, receipt_id: int) -> bool:
+    """
+    환불된 결제의 아웃박스를 REVOKE_PENDING으로. 없으면 생성(grant 선점). 멱등.
+      - 아웃박스 없음: REVOKE_PENDING으로 생성 → grant enroll(notin_)·dispatch(PENDING)가 모두 스킵 → 발급 선점 차단.
+      - PENDING/GRANTED: REVOKE_PENDING으로 전이.
+      - REVOKED/REVOKE_PENDING: no-op.
+    반환: 큐잉(변경/생성) 여부.
+    """
+    ob = sess.scalar(
+        select(VoucherGrantOutbox).where(VoucherGrantOutbox.receipt_id == receipt_id)
+    )
+    if ob is None:
+        sess.add(
+            VoucherGrantOutbox(
+                receipt_id=receipt_id, status=VoucherGrantStatus.REVOKE_PENDING
+            )
+        )
+        return True
+    if ob.status in (VoucherGrantStatus.REVOKED, VoucherGrantStatus.REVOKE_PENDING):
+        return False
+    ob.status = VoucherGrantStatus.REVOKE_PENDING
+    return True
+
+
+def enqueue_revoke_by_order_id(sess, order_id: str) -> bool:
+    """order_id(스토어 영수증)로 receipt 찾아 revoke 큐잉."""
+    r = sess.scalar(select(Receipt).where(Receipt.order_id == order_id))
+    if r is None:
+        return False
+    return enqueue_revoke_for_receipt(sess, r.id)
+
+
+def enqueue_revoke_by_order_ids(order_ids) -> int:
+    """
+    여러 order_id에 대해 revoke 큐잉(자체 세션 관리). track_google_refund 환불 감지 훅용.
+    voucher_grant_enabled=False면 no-op(0). 한 건 실패가 나머지를 막지 않음.
+    """
+    if not config.voucher_grant_enabled or not order_ids:
+        return 0
+    sess = scoped_session(sessionmaker(bind=engine))
+    n = 0
+    try:
+        for oid in order_ids:
+            try:
+                if enqueue_revoke_by_order_id(sess, oid):
+                    n += 1
+            except Exception as e:  # noqa: BLE001
+                logger.warning("enqueue revoke failed", order_id=oid, error=str(e))
+        sess.commit()
+        if n:
+            logger.info("refund → revoke queued", count=n)
+    except Exception:
+        sess.rollback()
+        raise
+    finally:
+        sess.remove()
+    return n
+
+
+@app.task(
+    name="iap.voucher_reconcile",
+    bind=True,
+    acks_late=True,
+    queue="background_job_queue",
+)
+def reconcile_vouchers(self):
+    """환불/무효 결제의 바우처 회수(beat, */5분)."""
+    if not config.voucher_grant_enabled:
+        return "voucher grant disabled"
+    if not (config.portal_revoke_url and config.portal_iap_jwt_secret):
+        logger.warning("voucher revoke not configured (url/secret missing)")
+        return "not configured"
+
+    sess = scoped_session(sessionmaker(bind=engine))
+    enqueued = revoked = failed = 0
+    try:
+        # (A) status 기반 enroll — 환불/무효 receipt를 가진 미회수 아웃박스 → REVOKE_PENDING.
+        #     (google buyer 환불은 status 미갱신이라 track_google_refund 훅이 담당; 여기선 admin 환불 등.)
+        rows = (
+            sess.execute(
+                select(VoucherGrantOutbox)
+                .join(Receipt, Receipt.id == VoucherGrantOutbox.receipt_id)
+                .where(
+                    VoucherGrantOutbox.status.in_(
+                        [VoucherGrantStatus.PENDING, VoucherGrantStatus.GRANTED]
+                    ),
+                    Receipt.status.in_(_REFUNDED_STATUSES),
+                )
+                .limit(ENROLL_BATCH)
+            )
+            .scalars()
+            .all()
+        )
+        for ob in rows:
+            ob.status = VoucherGrantStatus.REVOKE_PENDING
+            enqueued += 1
+        sess.commit()
+
+        # (B) revoke dispatch — REVOKE_PENDING → 포탈 revoke. 행 잠금으로 동시 실행 중복 방지.
+        pendings = (
+            sess.execute(
+                select(VoucherGrantOutbox)
+                .where(VoucherGrantOutbox.status == VoucherGrantStatus.REVOKE_PENDING)
+                .order_by(VoucherGrantOutbox.receipt_id)
+                .limit(REVOKE_BATCH)
+                .with_for_update(skip_locked=True)
+            )
+            .scalars()
+            .all()
+        )
+        for ob in pendings:
+            try:
+                r = sess.scalar(select(Receipt).where(Receipt.id == ob.receipt_id))
+                if r is None:
+                    ob.attempts = (ob.attempts or 0) + 1
+                    ob.last_error = "receipt not found (revoke)"
+                    continue
+                try:
+                    ok, ref, transient = _post_revoke(str(r.uuid))
+                except requests.RequestException as e:
+                    ob.attempts = (ob.attempts or 0) + 1
+                    ob.last_error = f"http error: {e}"[:500]
+                    continue
+
+                if ok:
+                    ob.status = VoucherGrantStatus.REVOKED
+                    ob.revoked_at = datetime.datetime.now(datetime.timezone.utc)
+                    ob.portal_ref = ref
+                    revoked += 1
+                else:
+                    # transient/4xx 모두 REVOKE_PENDING 유지(회수 유실=환불 NCG 잔존이므로 드롭 금지).
+                    ob.attempts = (ob.attempts or 0) + 1
+                    ob.last_error = f"{'transient' if transient else 'error'}: {ref}"
+                    if not transient:
+                        failed += 1
+            except Exception as e:  # noqa: BLE001
+                ob.attempts = (ob.attempts or 0) + 1
+                ob.last_error = f"unexpected: {e}"[:500]
+        sess.commit()
+
+        result = f"enqueued={enqueued} revoked={revoked} failed={failed}"
+        logger.info("voucher reconcile run", result=result)
+        if failed > 0:
+            _alert(f"[voucher-revoke] {failed} revoke(s) erroring (manual review). {result}")
+        return result
+    except Exception:
+        sess.rollback()
+        raise
+    finally:
+        sess.remove()

--- a/apps/worker/app/tasks/voucher_reconcile_task.py
+++ b/apps/worker/app/tasks/voucher_reconcile_task.py
@@ -14,6 +14,9 @@
   - revoke dispatch가 REVOKE_PENDING → 포탈 revoke → REVOKED.
 
 멱등: 포탈 revoke 자체가 iapUuid 기준 멱등(미개봉만 회수, 개봉건은 skippedOpened+경보). 재시도 안전.
+
+⚠️ known gap: Apple buyer 셀프 환불은 현재 신호 경로가 없다(google void tracker만 존재, status도 미갱신).
+   Apple 환불 회수는 App Store Server Notifications 처리기 도입 시 같은 enqueue_revoke_for_receipt로 연결 필요.
 """
 
 import datetime
@@ -22,30 +25,39 @@ from typing import Optional, Tuple
 import jwt
 import requests
 import structlog
-from shared.enums import ReceiptStatus, VoucherGrantStatus
+from shared.enums import ReceiptStatus, Store, VoucherGrantStatus
 from shared.models.receipt import Receipt
 from shared.models.voucher_grant_outbox import VoucherGrantOutbox
-from sqlalchemy import create_engine, select
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import scoped_session, sessionmaker
 
 from app.celery_app import app
 from app.config import config
 
-logger = structlog.get_logger(__name__)
+# grant 태스크와 엔진 공유 — 프로세스당 커넥션 풀 이중 생성 방지(커넥션 예산).
+from app.tasks.voucher_grant_task import engine
 
-engine = create_engine(
-    config.pg_dsn, pool_size=5, max_overflow=10, pool_recycle=3600, pool_pre_ping=True
-)
+logger = structlog.get_logger(__name__)
 
 HTTP_TIMEOUT = 10
 REVOKE_BATCH = 200
 ENROLL_BATCH = 500
+ALERT_ATTEMPTS = 5  # REVOKE_PENDING이 이 횟수 이상 재시도 중이면 스톨로 간주해 경보(회수 유실 진행중).
 _TRANSIENT_STATUS = {401, 403, 408, 429}
 # 환불/무효 — 발급된 바우처를 회수해야 하는 receipt 상태.
 _REFUNDED_STATUSES = [
     ReceiptStatus.REFUNDED_BY_ADMIN,
     ReceiptStatus.REFUNDED_BY_BUYER,
     ReceiptStatus.INVALID,
+]
+# google void → receipt 매칭 시 좁힐 스토어(order_id는 (store,order_id)로만 유일 → 크로스-스토어 오매칭 방지).
+_GOOGLE_STORES = [Store.GOOGLE, Store.GOOGLE_TEST]
+# 회수 대상 = 발급됐을 수 있는 모든 비-종단 상태 + FAILED(크래시창에 발급 후 FAILED 찍힌 건 포함).
+_REVOCABLE_OUTBOX_STATUSES = [
+    VoucherGrantStatus.PENDING,
+    VoucherGrantStatus.GRANTED,
+    VoucherGrantStatus.FAILED,
 ]
 
 
@@ -110,12 +122,24 @@ def enqueue_revoke_for_receipt(sess, receipt_id: int) -> bool:
         select(VoucherGrantOutbox).where(VoucherGrantOutbox.receipt_id == receipt_id)
     )
     if ob is None:
-        sess.add(
-            VoucherGrantOutbox(
-                receipt_id=receipt_id, status=VoucherGrantStatus.REVOKE_PENDING
+        # 신규 생성. grant enroll이 같은 receipt_id를 동시에 INSERT할 수 있으므로 SAVEPOINT로 격리 —
+        #   충돌 없으면 REVOKE_PENDING 생성, 충돌(grant가 선점)이면 재조회 후 전이(배치 통째 롤백 방지).
+        try:
+            with sess.begin_nested():
+                sess.add(
+                    VoucherGrantOutbox(
+                        receipt_id=receipt_id, status=VoucherGrantStatus.REVOKE_PENDING
+                    )
+                )
+            return True
+        except IntegrityError:
+            ob = sess.scalar(
+                select(VoucherGrantOutbox).where(
+                    VoucherGrantOutbox.receipt_id == receipt_id
+                )
             )
-        )
-        return True
+            if ob is None:  # 이론상 도달 불가
+                return False
     if ob.status in (VoucherGrantStatus.REVOKED, VoucherGrantStatus.REVOKE_PENDING):
         return False
     ob.status = VoucherGrantStatus.REVOKE_PENDING
@@ -123,11 +147,26 @@ def enqueue_revoke_for_receipt(sess, receipt_id: int) -> bool:
 
 
 def enqueue_revoke_by_order_id(sess, order_id: str) -> bool:
-    """order_id(스토어 영수증)로 receipt 찾아 revoke 큐잉."""
-    r = sess.scalar(select(Receipt).where(Receipt.order_id == order_id))
-    if r is None:
-        return False
-    return enqueue_revoke_for_receipt(sess, r.id)
+    """
+    google void의 order_id로 receipt 찾아 revoke 큐잉. 반환: 하나라도 큐잉되면 True.
+      ⚠️ order_id는 (store, order_id)로만 유일 → 스토어를 google 계열로 좁혀 크로스-스토어 오매칭 방지.
+         (다른 스토어의 동일 order_id를 잘못 회수하면 정상 유저 손해). 다중 매치는 모두 큐잉.
+    """
+    receipts = (
+        sess.execute(
+            select(Receipt).where(
+                Receipt.order_id == order_id,
+                Receipt.store.in_(_GOOGLE_STORES),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    queued = False
+    for r in receipts:
+        if enqueue_revoke_for_receipt(sess, r.id):
+            queued = True
+    return queued
 
 
 def enqueue_revoke_by_order_ids(order_ids) -> int:
@@ -181,9 +220,10 @@ def reconcile_vouchers(self):
                 select(VoucherGrantOutbox)
                 .join(Receipt, Receipt.id == VoucherGrantOutbox.receipt_id)
                 .where(
-                    VoucherGrantOutbox.status.in_(
-                        [VoucherGrantStatus.PENDING, VoucherGrantStatus.GRANTED]
-                    ),
+                    # FAILED 포함: grant가 HTTP 200(발급)後 commit前 크래시→재전달 사이 admin 환불 시
+                    # 재dispatch가 FAILED로 찍는데 바우처는 이미 발급됨 → 회수 누락 방지(revoke는 멱등이라
+                    # 미발급 receipt엔 no-op으로 무해).
+                    VoucherGrantOutbox.status.in_(_REVOCABLE_OUTBOX_STATUSES),
                     Receipt.status.in_(_REFUNDED_STATUSES),
                 )
                 .limit(ENROLL_BATCH)
@@ -201,7 +241,9 @@ def reconcile_vouchers(self):
             sess.execute(
                 select(VoucherGrantOutbox)
                 .where(VoucherGrantOutbox.status == VoucherGrantStatus.REVOKE_PENDING)
-                .order_by(VoucherGrantOutbox.receipt_id)
+                # attempts 오름차순 우선 — 영구 4xx 등 고-attempts 행이 batch 앞을 막아
+                # 신규 회수가 starve되지 않게(신규 attempts=0 먼저 처리).
+                .order_by(VoucherGrantOutbox.attempts, VoucherGrantOutbox.receipt_id)
                 .limit(REVOKE_BATCH)
                 .with_for_update(skip_locked=True)
             )
@@ -238,10 +280,27 @@ def reconcile_vouchers(self):
                 ob.last_error = f"unexpected: {e}"[:500]
         sess.commit()
 
-        result = f"enqueued={enqueued} revoked={revoked} failed={failed}"
+        # 스톨 경보 — transient(5xx/인증/레이트리밋)로 무한 재시도 중인 회수는 failed에 안 잡히므로
+        #   attempts 임계 이상 REVOKE_PENDING 백로그를 별도 집계해 알림(회수 유실이 진행 중일 수 있음).
+        stalled = (
+            sess.scalar(
+                select(func.count())
+                .select_from(VoucherGrantOutbox)
+                .where(
+                    VoucherGrantOutbox.status == VoucherGrantStatus.REVOKE_PENDING,
+                    VoucherGrantOutbox.attempts >= ALERT_ATTEMPTS,
+                )
+            )
+            or 0
+        )
+
+        result = f"enqueued={enqueued} revoked={revoked} failed={failed} stalled={stalled}"
         logger.info("voucher reconcile run", result=result)
-        if failed > 0:
-            _alert(f"[voucher-revoke] {failed} revoke(s) erroring (manual review). {result}")
+        if failed > 0 or stalled > 0:
+            _alert(
+                f"[voucher-revoke] 회수 실패/스톨 (수동 검토): failed={failed} "
+                f"stalled(attempts>={ALERT_ATTEMPTS})={stalled}. {result}"
+            )
         return result
     except Exception:
         sess.rollback()

--- a/apps/worker/tests/test_voucher_reconcile_task.py
+++ b/apps/worker/tests/test_voucher_reconcile_task.py
@@ -1,0 +1,107 @@
+from unittest.mock import MagicMock, patch
+
+from app.tasks import voucher_reconcile_task as vr
+from shared.enums import VoucherGrantStatus
+
+
+class TestPostRevoke:
+    def _resp(self, status, body=None):
+        r = MagicMock()
+        r.status_code = status
+        r.text = "err"
+        r.json = MagicMock(return_value=body if body is not None else {})
+        return r
+
+    def _run(self, resp):
+        with patch.object(vr.config, "portal_revoke_url", "http://portal/api/voucher/revoke"), \
+            patch.object(vr.config, "portal_iap_jwt_secret", "secret"), \
+            patch.object(vr.requests, "post", return_value=resp):
+            return vr._post_revoke("some-uuid")
+
+    def test_success(self):
+        ok, ref, transient = self._run(
+            self._resp(200, {"revoked": 2, "alreadyRevoked": 0, "skippedOpened": []})
+        )
+        assert ok is True and transient is False and "revoked=2" in ref
+
+    def test_skipped_opened_surfaced_in_ref(self):
+        ok, ref, transient = self._run(
+            self._resp(200, {"revoked": 1, "alreadyRevoked": 0, "skippedOpened": [7]})
+        )
+        assert ok is True and "skippedOpened=[7]" in ref
+
+    def test_5xx_transient(self):
+        ok, ref, transient = self._run(self._resp(503))
+        assert ok is False and transient is True
+
+    def test_auth_ratelimit_transient(self):
+        for status in (401, 403, 408, 429):
+            ok, ref, transient = self._run(self._resp(status))
+            assert ok is False and transient is True
+
+    def test_4xx_non_transient(self):
+        ok, ref, transient = self._run(self._resp(400, {}))
+        assert ok is False and transient is False
+
+    def test_non_object_body_non_transient(self):
+        ok, ref, transient = self._run(self._resp(200, "oops"))
+        assert ok is False and transient is False
+
+
+class TestEnqueueRevokeForReceipt:
+    def test_creates_when_absent(self):
+        sess = MagicMock()
+        sess.scalar.return_value = None
+        added = {}
+        sess.add.side_effect = lambda ob: added.setdefault("ob", ob)
+        assert vr.enqueue_revoke_for_receipt(sess, 42) is True
+        assert added["ob"].receipt_id == 42
+        assert added["ob"].status == VoucherGrantStatus.REVOKE_PENDING
+
+    def test_transitions_granted_to_revoke_pending(self):
+        sess = MagicMock()
+        ob = MagicMock()
+        ob.status = VoucherGrantStatus.GRANTED
+        sess.scalar.return_value = ob
+        assert vr.enqueue_revoke_for_receipt(sess, 42) is True
+        assert ob.status == VoucherGrantStatus.REVOKE_PENDING
+        sess.add.assert_not_called()
+
+    def test_transitions_pending_to_revoke_pending(self):
+        sess = MagicMock()
+        ob = MagicMock()
+        ob.status = VoucherGrantStatus.PENDING
+        sess.scalar.return_value = ob
+        assert vr.enqueue_revoke_for_receipt(sess, 42) is True
+        assert ob.status == VoucherGrantStatus.REVOKE_PENDING
+
+    def test_noop_when_already_revoked(self):
+        for st in (VoucherGrantStatus.REVOKED, VoucherGrantStatus.REVOKE_PENDING):
+            sess = MagicMock()
+            ob = MagicMock()
+            ob.status = st
+            sess.scalar.return_value = ob
+            assert vr.enqueue_revoke_for_receipt(sess, 42) is False
+            assert ob.status == st  # 변경 없음
+
+
+class TestReconcileGating:
+    def test_disabled_returns_early(self):
+        with patch.object(vr.config, "voucher_grant_enabled", False):
+            assert vr.reconcile_vouchers.run() == "voucher grant disabled"
+
+    def test_not_configured_returns_early(self):
+        with patch.object(vr.config, "voucher_grant_enabled", True), \
+            patch.object(vr.config, "portal_revoke_url", None), \
+            patch.object(vr.config, "portal_iap_jwt_secret", None):
+            assert vr.reconcile_vouchers.run() == "not configured"
+
+
+class TestEnqueueByOrderIds:
+    def test_noop_when_disabled(self):
+        with patch.object(vr.config, "voucher_grant_enabled", False):
+            assert vr.enqueue_revoke_by_order_ids(["o1", "o2"]) == 0
+
+    def test_noop_when_empty(self):
+        with patch.object(vr.config, "voucher_grant_enabled", True):
+            assert vr.enqueue_revoke_by_order_ids([]) == 0

--- a/apps/worker/tests/test_voucher_reconcile_task.py
+++ b/apps/worker/tests/test_voucher_reconcile_task.py
@@ -75,6 +75,15 @@ class TestEnqueueRevokeForReceipt:
         assert vr.enqueue_revoke_for_receipt(sess, 42) is True
         assert ob.status == VoucherGrantStatus.REVOKE_PENDING
 
+    def test_transitions_failed_to_revoke_pending(self):
+        # 🔴#2: 크래시창에 발급됐는데 FAILED 찍힌 건도 회수 대상 → 전이돼야 함.
+        sess = MagicMock()
+        ob = MagicMock()
+        ob.status = VoucherGrantStatus.FAILED
+        sess.scalar.return_value = ob
+        assert vr.enqueue_revoke_for_receipt(sess, 42) is True
+        assert ob.status == VoucherGrantStatus.REVOKE_PENDING
+
     def test_noop_when_already_revoked(self):
         for st in (VoucherGrantStatus.REVOKED, VoucherGrantStatus.REVOKE_PENDING):
             sess = MagicMock()
@@ -83,6 +92,23 @@ class TestEnqueueRevokeForReceipt:
             sess.scalar.return_value = ob
             assert vr.enqueue_revoke_for_receipt(sess, 42) is False
             assert ob.status == st  # 변경 없음
+
+
+class TestEnqueueByOrderId:
+    def test_handles_multiple_google_matches(self):
+        # order_id가 (store,order_id)로만 유일 → 다중 매치 시 모두 큐잉.
+        sess = MagicMock()
+        r1, r2 = MagicMock(), MagicMock()
+        r1.id, r2.id = 1, 2
+        sess.execute.return_value.scalars.return_value.all.return_value = [r1, r2]
+        with patch.object(vr, "enqueue_revoke_for_receipt", return_value=True) as m:
+            assert vr.enqueue_revoke_by_order_id(sess, "order-x") is True
+            assert m.call_count == 2
+
+    def test_no_match_returns_false(self):
+        sess = MagicMock()
+        sess.execute.return_value.scalars.return_value.all.return_value = []
+        assert vr.enqueue_revoke_by_order_id(sess, "order-x") is False
 
 
 class TestReconcileGating:


### PR DESCRIPTION
## 요약
환불 감지 → 포탈 `revoke` 호출을 아웃박스(`voucher_grant_outbox`)를 **단일 조율점**으로 처리. grant 트리거(#472) 위에 스택.

## 두 신호원 → REVOKE_PENDING
- **google buyer 환불**: `track_google_refund`가 void 감지 시 `order_id→receipt→enqueue_revoke` (google 환불은 `receipt.status`를 갱신하지 않으므로 이 훅이 유일 신호원). 알림 흐름과 독립·best-effort.
- **admin 환불/무효**(`status=REFUNDED_*/INVALID`): reconcile의 status 기반 enroll.

## reconcile beat(`*/5분`)
- (A) status enroll: 환불/무효 receipt의 미회수 아웃박스 → `REVOKE_PENDING`
- (B) revoke dispatch: `REVOKE_PENDING` → 포탈 revoke → `REVOKED`. 행잠금(`skip_locked`)·행별 격리·재시도

## 아웃박스가 단일 조율점인 이유
`REVOKE_PENDING`/`REVOKED` 행은 grant enroll(`notin_`)·dispatch(`PENDING`만)가 모두 스킵 → **환불이 grant보다 먼저 도착해도 발급이 선점적으로 차단**된다(아웃박스를 REVOKE_PENDING로 생성).

## 안전
- revoke 유실 = 미회수(환불 NCG 잔존)이므로 4xx도 드롭하지 않고 `REVOKE_PENDING` 유지 + 경보
- 포탈 revoke 자체가 iapUuid 멱등(미개봉만 회수, 개봉건 skippedOpened+경보)

## 테스트 14건
`_post_revoke` 응답분류, `enqueue_revoke_for_receipt` 상태전이(생성/전이/no-op), 게이팅.